### PR TITLE
feat(core): make root command exportable and add config bootstrapping

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -86,5 +86,5 @@ func init() {
 	cmd := man.Docs.GetCommand("auth",
 		man.WithSubcommands(clientCredentialsCmd),
 	)
-	rootCmd.AddCommand(&cmd.Command)
+	RootCmd.AddCommand(&cmd.Command)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,7 +21,6 @@ func config_updateOutput(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-
 	outputCmd := man.Docs.GetCommand("config/output",
 		man.WithRun(config_updateOutput),
 	)
@@ -34,5 +33,5 @@ func init() {
 	cmd := man.Docs.GetCommand("config",
 		man.WithSubcommands(outputCmd),
 	)
-	rootCmd.AddCommand(&cmd.Command)
+	RootCmd.AddCommand(&cmd.Command)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,7 +16,7 @@ func config_updateOutput(cmd *cobra.Command, args []string) {
 	flagHelper := cli.NewFlagHelper(cmd)
 	format := flagHelper.GetRequiredString("format")
 
-	config.UpdateOutputFormat(format)
+	config.UpdateOutputFormat(cfgKey, format)
 	fmt.Println(cli.SuccessMessage(fmt.Sprintf("Output format updated to %s", format)))
 }
 

--- a/cmd/dev-selectors.go
+++ b/cmd/dev-selectors.go
@@ -54,7 +54,7 @@ func dev_selectorsGen(cmd *cobra.Command, args []string) {
 
 	rows := [][]string{}
 	for _, r := range result {
-		rows = append(rows, []string{r.ExternalField, r.ExternalValue})
+		rows = append(rows, []string{r.ExternalSelectorValue, r.ExternalValue})
 	}
 
 	t := cli.NewTabular().Rows(rows...)
@@ -97,7 +97,7 @@ func dev_selectorsTest(cmd *cobra.Command, args []string) {
 
 	rows := [][]string{}
 	for _, r := range result {
-		rows = append(rows, []string{r.ExternalField, r.ExternalValue})
+		rows = append(rows, []string{r.ExternalSelectorValue, r.ExternalValue})
 	}
 
 	t := cli.NewTabular().Rows(rows...)

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -119,5 +119,5 @@ func init() {
 		man.WithRun(dev_designSystem),
 	)
 	devCmd.AddCommand(&designCmd.Command)
-	rootCmd.AddCommand(&devCmd.Command)
+	RootCmd.AddCommand(&devCmd.Command)
 }

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -12,5 +12,5 @@ func init() {
 			tui.StartTea()
 		}),
 	)
-	rootCmd.AddCommand(&cmd.Command)
+	RootCmd.AddCommand(&cmd.Command)
 }

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -20,5 +20,5 @@ func init() {
 		doc.GetDocFlag("json").DefaultAsBool(),
 		doc.GetDocFlag("json").Description,
 	)
-	rootCmd.AddCommand(policyCmd)
+	RootCmd.AddCommand(policyCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,16 +41,7 @@ func init() {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // The config file and key are defaulted to otdfctl.yaml.
 func Execute() {
-	cfg, err := config.LoadConfig("", "otdfctl")
-	if err != nil {
-		fmt.Println("Error loading config:", err)
-		os.Exit(1)
-	}
-	OtdfctlCfg = *cfg
-	err = RootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
+	ExecuteWithBootstrap("", "")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,26 +18,26 @@ var (
 	configFlagOverrides = config.ConfigFlagOverrides{}
 )
 
-// rootCmd represents the base command when called without any subcommands
+// RootCmd represents the base command when called without any subcommands.
 var (
-	rootCmd = &man.Docs.GetDoc("<root>").Command
+	RootCmd = &man.Docs.GetDoc("<root>").Command
 )
 
 func init() {
 	doc := man.Docs.GetDoc("<root>")
-	rootCmd = &doc.Command
-	rootCmd.PersistentFlags().String(
+	RootCmd = &doc.Command
+	RootCmd.PersistentFlags().String(
 		doc.GetDocFlag("host").Name,
 		doc.GetDocFlag("host").Default,
 		doc.GetDocFlag("host").Description,
 	)
-	rootCmd.PersistentFlags().StringVar(
+	RootCmd.PersistentFlags().StringVar(
 		&cfgFile,
 		doc.GetDocFlag("config-file").Name,
 		doc.GetDocFlag("config-file").Default,
 		doc.GetDocFlag("config-file").Description,
 	)
-	rootCmd.PersistentFlags().String(
+	RootCmd.PersistentFlags().String(
 		doc.GetDocFlag("log-level").Name,
 		doc.GetDocFlag("log-level").Default,
 		doc.GetDocFlag("log-level").Description,
@@ -53,7 +53,7 @@ func init() {
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 func Execute() {
-	err := rootCmd.Execute()
+	err := RootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	cfgFile    string
+	cfgKey     string
 	OtdfctlCfg config.Config
 
 	configFlagOverrides = config.ConfigFlagOverrides{}
@@ -31,29 +31,39 @@ func init() {
 		doc.GetDocFlag("host").Default,
 		doc.GetDocFlag("host").Description,
 	)
-	RootCmd.PersistentFlags().StringVar(
-		&cfgFile,
-		doc.GetDocFlag("config-file").Name,
-		doc.GetDocFlag("config-file").Default,
-		doc.GetDocFlag("config-file").Description,
-	)
 	RootCmd.PersistentFlags().String(
 		doc.GetDocFlag("log-level").Name,
 		doc.GetDocFlag("log-level").Default,
 		doc.GetDocFlag("log-level").Description,
 	)
+}
 
-	cfg, err := config.LoadConfig("otdfctl")
+// Execute adds all child commands to the root command and sets flags appropriately.
+// The config file and key are defaulted to otdfctl.yaml.
+func Execute() {
+	cfg, err := config.LoadConfig("", "otdfctl")
 	if err != nil {
 		fmt.Println("Error loading config:", err)
 		os.Exit(1)
 	}
 	OtdfctlCfg = *cfg
+	err = RootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
-func Execute() {
-	err := RootCmd.Execute()
+// It also allows the config file & key to be bootstrapped for wrapping the CLI.
+func ExecuteWithBootstrap(configFile, configKey string) {
+	cfgKey = configKey
+	cfg, err := config.LoadConfig(configFile, configKey)
+	if err != nil {
+		fmt.Println("Error loading config:", err)
+		os.Exit(1)
+	}
+	OtdfctlCfg = *cfg
+	err = RootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/docs/man/_index.md
+++ b/docs/man/_index.md
@@ -8,9 +8,6 @@ command:
     - name: host
       description: host:port of the Virtru Data Security Platform gRPC server
       default: localhost:8080
-    - name: config-file
-      description: config file (default is $HOME/.otdfctl.yaml)
-      default: ''
     - name: log-level
       description: log level (debug, info, warn, error, fatal, panic)
       default: info

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/itchyny/gojq v0.12.15
 	github.com/muesli/reflow v0.3.0
-	github.com/opentdf/platform/protocol/go v0.0.0-20240328192545-ab689ebe9123
+	github.com/opentdf/platform/protocol/go v0.0.0-20240419180709-f27ab98e49a2
 	github.com/opentdf/platform/sdk v0.0.0-20240328192545-ab689ebe9123
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2sz
 github.com/opentdf/platform/protocol/go v0.0.0-20240328192545-ab689ebe9123 h1:otRtkhiBu075GliWAxX12QpiK4dlJdeOtSjomfJ25h0=
 github.com/opentdf/platform/protocol/go v0.0.0-20240328192545-ab689ebe9123/go.mod h1:QcLUArzpnfaLehOin8EBM77dCyyUwlRg/kH6uhy+HVE=
 github.com/opentdf/platform/protocol/go v0.0.0-20240403220730-0dc1115f9822/go.mod h1:QcLUArzpnfaLehOin8EBM77dCyyUwlRg/kH6uhy+HVE=
+github.com/opentdf/platform/protocol/go v0.0.0-20240419180709-f27ab98e49a2 h1:bZyQ2PdXlZiq/eEx/Iw9utIrrb75XrqEbUYbcO5YxNU=
+github.com/opentdf/platform/protocol/go v0.0.0-20240419180709-f27ab98e49a2/go.mod h1:qOBx0d9F2dGeTc703tp+HCGhW6nLYXKZ+vmZ2H9xcPI=
 github.com/opentdf/platform/sdk v0.0.0-20240328192545-ab689ebe9123 h1:flVFbXMjPRZ8t9GRxoGAva14qEMia1DOQbkJvb3ImXs=
 github.com/opentdf/platform/sdk v0.0.0-20240328192545-ab689ebe9123/go.mod h1:+HlyE1QyT7HsW5UlDGnBZVm0YdEfdv7g+K6pWDV8OAg=
 github.com/opentdf/platform/sdk v0.0.0-20240403220730-0dc1115f9822/go.mod h1:qRjuZshMizjv7u0K7smgdfSuKz4x7XZb7sJqSdzop+c=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,7 @@ func LoadConfig(file string, key string) (*Config, error) {
 	// default the config values if not passed in
 	if file == "" && key == "" {
 		key = "otdfctl"
-		slog.Debug("LoadConfig: file & key not provided, using default file", "config file", file)
+		slog.Debug("LoadConfig: file and key not provided, using default file", "config file", file)
 	} else {
 		slog.Debug("LoadConfig", "config file", file, "config key", key)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,12 +38,13 @@ const (
 )
 
 // Load config with viper.
-func LoadConfig(key string) (*Config, error) {
-	if key == "" {
+func LoadConfig(file string, key string) (*Config, error) {
+	// default the config values if not passed in
+	if file == "" && key == "" {
 		key = "otdfctl"
-		slog.Debug("LoadConfig: key not provided, using default", "config file", key)
+		slog.Debug("LoadConfig: file & key not provided, using default file", "config file", file)
 	} else {
-		slog.Debug("LoadConfig", "config file", key)
+		slog.Debug("LoadConfig", "config file", file, "config key", key)
 	}
 
 	config := &Config{}
@@ -61,6 +62,12 @@ func LoadConfig(key string) (*Config, error) {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
+	// Allow for a custom config file to be passed in
+	// This takes precedence over the AddConfigPath/SetConfigName
+	if file != "" {
+		viper.SetConfigFile(file)
+	}
+
 	if err := viper.ReadInConfig(); err != nil {
 		return nil, errors.Join(err, ErrLoadingConfig)
 	}
@@ -77,13 +84,17 @@ func LoadConfig(key string) (*Config, error) {
 	return config, nil
 }
 
-func UpdateOutputFormat(format string) {
+func UpdateOutputFormat(cfgKey, format string) {
 	v := viper.GetViper()
 	format = strings.ToLower(format)
+	formatter := "output.format"
+	if cfgKey != "" {
+		formatter = cfgKey + "." + formatter
+	}
 	if format == OutputJSON {
-		v.Set("output.format", OutputJSON)
+		v.Set(formatter, OutputJSON)
 	} else {
-		v.Set("output.format", OutputStyled)
+		v.Set(formatter, OutputStyled)
 	}
 	viper.WriteConfig()
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,10 @@ import (
 	"github.com/opentdf/otdfctl/cmd"
 )
 
+func Execute() {
+	cmd.Execute()
+}
+
 func main() {
 	// f, err := os.Create("cpu.pprof")
 	// if err != nil {
@@ -23,5 +27,5 @@ func main() {
 
 	slog.SetDefault(logger)
 
-	cmd.Execute()
+	Execute()
 }

--- a/main.go
+++ b/main.go
@@ -7,10 +7,6 @@ import (
 	"github.com/opentdf/otdfctl/cmd"
 )
 
-func Execute() {
-	cmd.Execute()
-}
-
 func main() {
 	// f, err := os.Create("cpu.pprof")
 	// if err != nil {
@@ -27,5 +23,5 @@ func main() {
 
 	slog.SetDefault(logger)
 
-	Execute()
+	cmd.Execute()
 }

--- a/pkg/handlers/selectors.go
+++ b/pkg/handlers/selectors.go
@@ -69,7 +69,7 @@ func ProcessSubjectContext(subject interface{}, currSelector string, result []*p
 		reflect.Float64,
 		reflect.Complex64,
 		reflect.Complex128:
-		result = append(result, &policy.SubjectProperty{ExternalField: currSelector + "'", ExternalValue: fmt.Sprintf("%v", subject)})
+		result = append(result, &policy.SubjectProperty{ExternalSelectorValue: currSelector + "'", ExternalValue: fmt.Sprintf("%v", subject)})
 
 	default:
 		return nil, fmt.Errorf("unsupported type %v", currType.Kind())
@@ -136,7 +136,7 @@ func TestSubjectContext(subject interface{}, selectors []string) ([]*policy.Subj
 				// ignore error: we don't have a match but that is not an error state in this case
 			} else {
 				if v != nil {
-					found = append(found, &policy.SubjectProperty{ExternalField: "'" + s + "'", ExternalValue: fmt.Sprintf("%v", v)})
+					found = append(found, &policy.SubjectProperty{ExternalSelectorValue: "'" + s + "'", ExternalValue: fmt.Sprintf("%v", v)})
 				}
 			}
 		}


### PR DESCRIPTION
- Allow root command to be exported for ease of consumption in wrapper CLIs and processes
- Add new `ExecuteWithBootstrap` command for injection of a separate config 
- Remove `config-file` CLI flag suffering from race condition between Viper & Cobra loading first in our "update format" flow