### PR TITLE
feat(core): enhance auth functionalities of CLI

### DIFF
--- a/cmd/auth-clearCachedCredentials.go
+++ b/cmd/auth-clearCachedCredentials.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/opentdf/otdfctl/pkg/cli"
+	"github.com/opentdf/otdfctl/pkg/handlers"
+	"github.com/opentdf/otdfctl/pkg/man"
+	"github.com/spf13/cobra"
+	"github.com/zalando/go-keyring"
+)
+
+var clearCachedCredsCmd = man.Docs.GetCommand("auth/clear-cached-credentials",
+	man.WithRun(auth_clearCreds),
+)
+
+func auth_clearCreds(cmd *cobra.Command, args []string) {
+	cachedClientID, err := handlers.GetClientIDFromCache()
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			fmt.Println("No client-id found in the cache to clear.")
+		} else {
+			cli.ExitWithError("Failed to retrieve client id from keyring", err)
+		}
+	}
+
+	// clear the client ID and secret from the keyring
+	err = keyring.Delete(handlers.TOKEN_URL, cachedClientID)
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			fmt.Println("No client secret found in the cache to clear under client-id: ", cachedClientID)
+		} else {
+			cli.ExitWithError("Failed to clear client secret from keyring", err)
+		}
+	}
+
+	err = keyring.Delete(handlers.TOKEN_URL, handlers.OTDFCTL_CLIENT_ID_CACHE_KEY)
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			fmt.Println("No client id found in the cache to clear.")
+		} else {
+			cli.ExitWithError("Failed to clear client id from keyring", err)
+		}
+	}
+
+	err = keyring.Delete(handlers.TOKEN_URL, handlers.OTDFCTL_OIDC_TOKEN_KEY)
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			fmt.Println("No token found in the cache to clear.")
+		} else {
+			cli.ExitWithError("Failed to clear token from keyring", err)
+		}
+	}
+
+	fmt.Println(cli.SuccessMessage("Cached client credentials and token are clear."))
+}

--- a/cmd/auth-clientCredentials.go
+++ b/cmd/auth-clientCredentials.go
@@ -45,10 +45,7 @@ func auth_clientCredentials(cmd *cobra.Command, args []string) {
 
 	_, err := handlers.GetTokenWithClientCredentials(cmd.Context(), clientID, clientSecret, handlers.TOKEN_URL, false)
 	if err != nil {
-		errMsg := cli.ErrorMessage("An error occurred during login. Please check your credentials and try again.", nil)
-		fmt.Println(errMsg)
-		cli.ExitWithError(errMsg, err)
-		return
+		cli.ExitWithError("An error occurred during login. Please check your credentials and try again", err)
 	}
 
 	fmt.Println(cli.SuccessMessage("Successfully logged in with client ID and secret"))

--- a/cmd/auth-clientCredentials.go
+++ b/cmd/auth-clientCredentials.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/opentdf/otdfctl/pkg/cli"
+	"github.com/opentdf/otdfctl/pkg/handlers"
+	"github.com/opentdf/otdfctl/pkg/man"
+	"github.com/spf13/cobra"
+	"github.com/zalando/go-keyring"
+)
+
+var clientCredentialsCmd = man.Docs.GetCommand("auth/client-credentials",
+	man.WithRun(auth_clientCredentials),
+)
+
+func auth_clientCredentials(cmd *cobra.Command, args []string) {
+	h := cli.NewHandler(cmd)
+	defer h.Close()
+
+	flagHelper := cli.NewFlagHelper(cmd)
+	clientId := flagHelper.GetOptionalString("client-id")
+	clientSecret := flagHelper.GetOptionalString("client-secret")
+
+	// check if we have a clientId in the keyring, if a null value is passed in
+	if clientId == "" {
+		fmt.Println("No client-id provided. Attempting to retrieve the default from keyring.")
+		retrievedClientID, errID := keyring.Get(handlers.TOKEN_URL, handlers.OTDFCTL_CLIENT_ID_CACHE_KEY)
+		if errID == nil {
+			clientId = retrievedClientID
+			fmt.Println(cli.SuccessMessage("Retrieved stored clientId from keyring"))
+		}
+	}
+
+	// now lets check if we still don't have it, and if not, throw and error
+	if clientId == "" {
+		errMsg := fmt.Sprintf("Please provide required flag: (%s)", "client-id")
+		fmt.Println(cli.ErrorMessage(errMsg, nil))
+		cli.ExitWithError("Failed to create attribute", nil)
+		return
+	}
+
+	// check if we have a clientSecret in the keyring, if a null value is passed in
+	if clientSecret == "" {
+		retrievedSecret, krErr := keyring.Get(handlers.TOKEN_URL, clientId)
+		if krErr == nil {
+			clientSecret = retrievedSecret
+			fmt.Println(cli.SuccessMessage("Retrieved stored clientSecret from keyring"))
+		}
+	}
+	// check if we still don't have it, and if not throw an error
+	if clientSecret == "" {
+		errMsg := fmt.Sprintf("Please provide required flag: (%s)", "client-secret")
+		fmt.Println(cli.ErrorMessage(errMsg, nil))
+		cli.ExitWithError("Failed to create attribute", nil)
+		return
+	}
+
+	// for now we're hardcoding the TOKEN_URL as a constant at the top
+	_, err := h.GetTokenWithClientCredentials(clientId, clientSecret, handlers.TOKEN_URL, false)
+	if err != nil {
+		errMsg := cli.ErrorMessage("An error occurred during login. Please check your credentials and try again.", nil)
+		fmt.Println(errMsg)
+		cli.ExitWithError(errMsg, err)
+		return
+	}
+
+	fmt.Println(cli.SuccessMessage("Successfully logged in with client ID and secret"))
+}
+
+func init() {
+	clientCredentialsCmd := man.Docs.GetCommand("auth/client-credentials",
+		man.WithRun(auth_clientCredentials),
+	)
+	clientCredentialsCmd.Flags().String(
+		clientCredentialsCmd.GetDocFlag("client-id").Name,
+		clientCredentialsCmd.GetDocFlag("client-id").Default,
+		clientCredentialsCmd.GetDocFlag("client-id").Description,
+	)
+	clientCredentialsCmd.Flags().String(
+		clientCredentialsCmd.GetDocFlag("client-secret").Name,
+		clientCredentialsCmd.GetDocFlag("client-secret").Default,
+		clientCredentialsCmd.GetDocFlag("client-secret").Description,
+	)
+}

--- a/cmd/auth-printAccessToken.go
+++ b/cmd/auth-printAccessToken.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/opentdf/otdfctl/pkg/cli"
+	"github.com/opentdf/otdfctl/pkg/handlers"
+	"github.com/opentdf/otdfctl/pkg/man"
+	"github.com/spf13/cobra"
+)
+
+var printAccessToken = man.Docs.GetCommand("auth/print-access-token",
+	man.WithRun(auth_printAccessToken),
+)
+
+func auth_printAccessToken(cmd *cobra.Command, args []string) {
+	tok, err := handlers.GetOIDCTokenFromCache()
+	if err != nil {
+		cli.ExitWithError("Failed to get OIDC token from cache", err)
+	}
+	fmt.Print(tok)
+}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,90 +1,13 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/opentdf/otdfctl/pkg/cli"
-	"github.com/opentdf/otdfctl/pkg/handlers"
 	"github.com/opentdf/otdfctl/pkg/man"
-	"github.com/spf13/cobra"
-	"github.com/zalando/go-keyring"
 )
 
-func auth_clientCredentials(cmd *cobra.Command, args []string) {
-	h := cli.NewHandler(cmd)
-	defer h.Close()
-
-	flagHelper := cli.NewFlagHelper(cmd)
-	clientId := flagHelper.GetOptionalString("client-id")
-	clientSecret := flagHelper.GetOptionalString("client-secret")
-	// noCache := flagHelper.GetOptionalString("noCache")
-	errMsg := fmt.Sprintf("Please provide required flag: (%s)", "Param Not Found")
-
-	// h.DEBUG_PrintKeyRingSecrets()
-
-	// check if we have a clientId in the keyring, if a null value is passed in
-	if clientId == "" {
-		fmt.Println("No client-id provided. Attempting to retrieve the default from keyring.")
-		retrievedClientID, errID := keyring.Get(handlers.TOKEN_URL, handlers.OTDFCTL_CLIENT_ID_CACHE_KEY)
-		if errID == nil {
-			clientId = retrievedClientID
-			fmt.Println(cli.SuccessMessage("Retrieved stored clientId from keyring"))
-		}
-	}
-
-	// now lets check if we still don't have it, and if not, throw and error
-	if clientId == "" {
-		errMsg = fmt.Sprintf("Please provide required flag: (%s)", "client-id")
-		fmt.Println(cli.ErrorMessage(errMsg, nil))
-		cli.ExitWithError("Failed to create attribute", nil)
-		return
-	}
-
-	// check if we have a clientSecret in the keyring, if a null value is passed in
-	if clientSecret == "" {
-		retrievedSecret, krErr := keyring.Get(handlers.TOKEN_URL, clientId)
-		if krErr == nil {
-			clientSecret = retrievedSecret
-			fmt.Println(cli.SuccessMessage("Retrieved stored clientSecret from keyring"))
-		}
-	}
-	// check if we still don't have it, and if not throw an error
-	if clientSecret == "" {
-		errMsg = fmt.Sprintf("Please provide required flag: (%s)", "client-secret")
-		fmt.Println(cli.ErrorMessage(errMsg, nil))
-		cli.ExitWithError("Failed to create attribute", nil)
-		return
-	}
-
-	// for now we're hardcoding the TOKEN_URL as a constant at the top
-	_, err := h.GetTokenWithClientCredentials(clientId, clientSecret, handlers.TOKEN_URL, false)
-	if err != nil {
-		errMsg = cli.ErrorMessage("An error occurred during login. Please check your credentials and try again.", nil)
-		fmt.Println(errMsg)
-		cli.ExitWithError(errMsg, err)
-		return
-	}
-
-	fmt.Println(cli.SuccessMessage("Successfully logged in with client ID and secret"))
-}
-
 func init() {
-	clientCredentialsCmd := man.Docs.GetCommand("auth/client-credentials",
-		man.WithRun(auth_clientCredentials),
-	)
-	clientCredentialsCmd.Flags().String(
-		clientCredentialsCmd.GetDocFlag("client-id").Name,
-		clientCredentialsCmd.GetDocFlag("client-id").Default,
-		clientCredentialsCmd.GetDocFlag("client-id").Description,
-	)
-	clientCredentialsCmd.Flags().String(
-		clientCredentialsCmd.GetDocFlag("client-secret").Name,
-		clientCredentialsCmd.GetDocFlag("client-secret").Default,
-		clientCredentialsCmd.GetDocFlag("client-secret").Description,
-	)
-
 	cmd := man.Docs.GetCommand("auth",
 		man.WithSubcommands(clientCredentialsCmd),
+		man.WithSubcommands(printAccessToken),
 	)
 	RootCmd.AddCommand(&cmd.Command)
 }

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -8,6 +8,7 @@ func init() {
 	cmd := man.Docs.GetCommand("auth",
 		man.WithSubcommands(clientCredentialsCmd),
 		man.WithSubcommands(printAccessToken),
+		man.WithSubcommands(clearCachedCredsCmd),
 	)
 	RootCmd.AddCommand(&cmd.Command)
 }

--- a/docs/man/auth/clear-cached-credentials.md
+++ b/docs/man/auth/clear-cached-credentials.md
@@ -1,0 +1,8 @@
+---
+title: Clear any cached OIDC token and client ID/Secret granted through the client credentials flow
+
+command:
+  name: clear-cached-credentials
+---
+
+Clear any cached OIDC token and client ID/Secret on the native OS granted through the client credentials flow.

--- a/docs/man/auth/print-access-token.md
+++ b/docs/man/auth/print-access-token.md
@@ -5,4 +5,4 @@ command:
   name: print-access-token
 ---
 
-Retrieves the cached OIDC token from the OS-specific keychain and prints if found.
+Retrieves the cached OIDC Access Token from the OS-specific keychain and prints to stdout if found.

--- a/docs/man/auth/print-access-token.md
+++ b/docs/man/auth/print-access-token.md
@@ -1,0 +1,8 @@
+---
+title: Print the cached OIDC access token (if found)
+
+command:
+  name: print-access-token
+---
+
+Retrieves the cached OIDC token from the OS-specific keychain and prints if found.

--- a/pkg/cli/handlers.go
+++ b/pkg/cli/handlers.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/opentdf/otdfctl/pkg/handlers"
 	"github.com/spf13/cobra"
 )
@@ -9,6 +12,9 @@ func NewHandler(cmd *cobra.Command) handlers.Handler {
 	platformEndpoint := cmd.Flag("host").Value.String()
 	h, err := handlers.New(platformEndpoint)
 	if err != nil {
+		if errors.Is(err, handlers.ErrUnauthenticated) {
+			ExitWithError(fmt.Sprintf("Not logged in. Please authenticate via CLI auth flow(s) before using command (%s)", cmd.Use), err)
+		}
 		ExitWithError("Failed to connect to server", err)
 	}
 	return h

--- a/pkg/handlers/sdk.go
+++ b/pkg/handlers/sdk.go
@@ -2,12 +2,17 @@ package handlers
 
 import (
 	"context"
+	"errors"
 
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/sdk"
 )
 
-var SDK *sdk.SDK
+var (
+	SDK *sdk.SDK
+
+	ErrUnauthenticated = errors.New("unauthenticated")
+)
 
 type Handler struct {
 	sdk              *sdk.SDK


### PR DESCRIPTION
1. Adds `print-access-token` subcommand In the style of gcloud's CLI: https://cloud.google.com/sdk/gcloud/reference/auth/print-access-token
2. Adds `clear-cached-credentials` subcommand to remove any client ID, secret, and token found on the native OS

Closes #136 