### PR TITLE
fix: allow setting --config-file and --config-key

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ func init() {
 		doc.GetDocFlag("with-client-creds").Description,
 	)
 	RootCmd.AddGroup(&cobra.Group{ID: "tdf"})
-	RootCmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
+	RootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		configFile, _ := cmd.Flags().GetString("config-file")
 		configKey, _ := cmd.Flags().GetString("config-key")
 

--- a/docs/man/_index.md
+++ b/docs/man/_index.md
@@ -5,6 +5,12 @@ command:
   name: otdfctl
   aliases: []
   flags:
+    - name: config-file
+      description: path to the configuration file
+      default: ''
+    - name: config-key
+      description: key is the name of the configuration file without the extension
+      default: 'otdfctl'
     - name: host
       description: host:port of the OpenTDF Platform gRPC server
       default: localhost:8080


### PR DESCRIPTION
Adds two new flags for setting the config-file and config-key. The config now tries to get loaded in the `PersistentPreRunE` func off of the rootcmd. 