### PR TITLE
fix(core): fix LIST command helper output to include all subcommands up to root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/huh v0.4.2
 	github.com/charmbracelet/lipgloss v0.11.0
 	github.com/creasty/defaults v1.7.0
+	github.com/evertras/bubble-table v0.16.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/itchyny/gojq v0.12.16
@@ -43,7 +44,6 @@ require (
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/evertras/bubble-table v0.16.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect

--- a/pkg/cli/tabular.go
+++ b/pkg/cli/tabular.go
@@ -41,7 +41,12 @@ func getJsonHelper(command string) string {
 }
 
 func PrintSuccessTable(cmd *cobra.Command, id string, t table.Model) {
-	resource := cmd.Parent().Use
+	parent := cmd.Parent()
+	resource := parent.Use
+	for parent.Parent() != nil {
+		resource = parent.Parent().Use + " " + resource
+		parent = parent.Parent()
+	}
 
 	var msg struct {
 		verb   string


### PR DESCRIPTION
Closes #194 

```shell
jakevanvorhis:otdfctl jake.vanvorhis$ go run . policy attributes list --host http://localhost:8080
  SUCCESS   Found otdfctl policy attributes list                                                                                                                       
                                                                                                                                                                       
╭─────────────────────────────────────┬─────────────────────────────┬──────────────────────┬───────────────┬───────────────┬───────────────┬────────┬────────┬────────╮
│ID                                   │Namespace                    │Name                  │Rule           │Values         │Active         │Labels  │Created…│Updated…│
├─────────────────────────────────────┼─────────────────────────────┼──────────────────────┼───────────────┼───────────────┼───────────────┼────────┼────────┼────────┤
│6fd59ec4-9efd-48c5-a613-d49208833ba1 │demo.com                     │codeowners            │HIERARCHY      │[hello]        │true           │[]      │Tue Jun…│Wed Jun…│
╰─────────────────────────────────────┴─────────────────────────────┴──────────────────────┴───────────────┴───────────────┴───────────────┴────────┴────────┴────────╯
  NOTE   Use 'otdfctl policy attributes get --id=<id> --json' to see all properties   
  
  jakevanvorhis:otdfctl jake.vanvorhis$ go run . policy attributes namespaces list --host http://localhost:8080
  SUCCESS   Found otdfctl policy attributes namespaces list                                                                                                            
                                                                                                                                                                       
╭─────────────────────────────────────┬────────────────┬────────────────┬────────────────┬────────────────┬────────────────╮                                           
│ID                                   │Name            │Active          │Labels          │Created At      │Updated At      │                                           
├─────────────────────────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┤                                           
│4bfe1f6e-b7c4-4dbf-bfd1-d112e761daa8 │demo.com        │true            │[]              │Tue Jun 11 20:1…│Tue Jun 11 20:1…│                                           
│aeffd9d1-0528-4991-ab40-83a24bee5e92 │example.com     │true            │[]              │Tue Jun 11 20:2…│Tue Jun 11 20:2…│                                           
╰─────────────────────────────────────┴────────────────┴────────────────┴────────────────┴────────────────┴────────────────╯                                           
  NOTE   Use 'otdfctl policy attributes namespaces get --id=<id> --json' to see all properties                            
  ```