### PR TITLE
chore(ci): Go 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentdf/otdfctl
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/adrg/frontmatter v0.2.0


### PR DESCRIPTION
The version of Go used was updated to 1.22.5 from 1.22.4 in the project's go.mod file. This change ensures the project is running on the latest stable release of Go for the best possible performance and security. see https://pkg.go.dev/vuln/GO-2024-2963