### PR TITLE
fix(core): fix error handler to avoid metadata labels panic

### DIFF
--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,6 +10,10 @@ import (
 )
 
 func ExitWithError(errMsg string, err error) {
+	if err == nil {
+		// ensure message and exit are satisfied even if nil error passed
+		err = errors.New("")
+	}
 	ExitWithNotFoundError(errMsg, err)
 	if err != nil {
 		fmt.Println(ErrorMessage(errMsg, err))


### PR DESCRIPTION
Closes https://github.com/opentdf/otdfctl/issues/113

Resolve issue where `cli.ExitWithError` was not exiting the process and panicking in some scenarious because `nil` errors were passed into it.