### PR TITLE
fix(core): remove deprecated policy members

### DIFF
--- a/pkg/cli/confirm.go
+++ b/pkg/cli/confirm.go
@@ -18,11 +18,6 @@ const (
 	ActionReactivate   = "reactivate"
 	ActionDelete       = "delete"
 
-	// member actions
-	ActionMemberAdd     = "add members"
-	ActionMemberRemove  = "remove members"
-	ActionMemberReplace = "replace all existing members"
-
 	// text input names
 	InputNameFQN        = "fully qualified name (FQN)"
 	InputNameFQNUpdated = "deprecated fully qualified name (FQN) being altered"

--- a/pkg/cli/sdkHelpers.go
+++ b/pkg/cli/sdkHelpers.go
@@ -22,7 +22,6 @@ type SimpleAttribute struct {
 type SimpleAttributeValue struct {
 	Id       string
 	FQN      string
-	Members  []string
 	Active   string
 	Metadata map[string]string
 }
@@ -65,14 +64,9 @@ func GetSimpleAttribute(a *policy.Attribute) SimpleAttribute {
 }
 
 func GetSimpleAttributeValue(v *policy.Value) SimpleAttributeValue {
-	memberIds := []string{}
-	for _, m := range v.GetMembers() {
-		memberIds = append(memberIds, m.GetId())
-	}
 	return SimpleAttributeValue{
 		Id:       v.GetId(),
 		FQN:      v.GetFqn(),
-		Members:  memberIds,
 		Active:   strconv.FormatBool(v.Active.GetValue()),
 		Metadata: ConstructMetadata(v.GetMetadata()),
 	}

--- a/pkg/handlers/attributeValues.go
+++ b/pkg/handlers/attributeValues.go
@@ -41,10 +41,9 @@ func (h *Handler) GetAttributeValue(id string) (*policy.Value, error) {
 }
 
 // Updates and returns updated value
-func (h *Handler) UpdateAttributeValue(id string, memberIds []string, metadata *common.MetadataMutable, behavior common.MetadataUpdateEnum) (*policy.Value, error) {
+func (h *Handler) UpdateAttributeValue(id string, metadata *common.MetadataMutable, behavior common.MetadataUpdateEnum) (*policy.Value, error) {
 	resp, err := h.sdk.Attributes.UpdateAttributeValue(h.ctx, &attributes.UpdateAttributeValueRequest{
 		Id:                     id,
-		Members:                memberIds,
 		Metadata:               metadata,
 		MetadataUpdateBehavior: behavior,
 	})


### PR DESCRIPTION
Downstream of platform issues [984](https://github.com/opentdf/platform/issues/984) & [1095](https://github.com/opentdf/platform/issues/1095) to deprecate attribute value members.