### PR TITLE
fix: create new http client to ignore tls verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ otdfctl.yaml
 
 # Ignore the tructl binary
 otdfctl
+otdfctl_testbuild
+
+# Misc
+creds.json
 
 # Hugo
 public/

--- a/cmd/auth-login.go
+++ b/cmd/auth-login.go
@@ -17,7 +17,7 @@ func auth_codeLogin(cmd *cobra.Command, args []string) {
 	printer := cli.NewPrinter(true)
 
 	printer.Println("Initiating login...")
-	tok, publicClientID, err := auth.LoginWithPKCE(cp.GetEndpoint(), clientID, tlsNoVerify)
+	tok, publicClientID, err := auth.LoginWithPKCE(cmd.Context(), cp.GetEndpoint(), clientID, tlsNoVerify)
 	if err != nil {
 		cli.ExitWithError("could not authenticate", err)
 	}
@@ -28,9 +28,9 @@ func auth_codeLogin(cmd *cobra.Command, args []string) {
 		AuthType: profiles.PROFILE_AUTH_TYPE_ACCESS_TOKEN,
 		AccessToken: profiles.AuthCredentialsAccessToken{
 			PublicClientID: publicClientID,
-			AccessToken:  tok.AccessToken,
-			Expiration:   tok.Expiry.Unix(),
-			RefreshToken: tok.RefreshToken,
+			AccessToken:    tok.AccessToken,
+			Expiration:     tok.Expiry.Unix(),
+			RefreshToken:   tok.RefreshToken,
 		},
 	}); err != nil {
 		cli.ExitWithError("failed to set auth credentials", err)

--- a/cmd/auth-logout.go
+++ b/cmd/auth-logout.go
@@ -19,7 +19,13 @@ func auth_logout(cmd *cobra.Command, args []string) {
 	creds := cp.GetAuthCredentials()
 	if creds.AuthType == profiles.PROFILE_AUTH_TYPE_ACCESS_TOKEN {
 		printer.Println("Revoking access token...")
-		if err := auth.RevokeAccessToken(cp.GetEndpoint(), creds.AccessToken.PublicClientID, creds.AccessToken.RefreshToken, tlsNoVerify); err != nil {
+		if err := auth.RevokeAccessToken(
+			cmd.Context(),
+			cp.GetEndpoint(),
+			creds.AccessToken.PublicClientID,
+			creds.AccessToken.RefreshToken,
+			tlsNoVerify,
+		); err != nil {
 			printer.Println("failed")
 			cli.ExitWithError("An error occurred while revoking the access token", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,8 @@ func InitProfile(cmd *cobra.Command, onlyNew bool) *profiles.ProfileStore {
 // TODO make this a preRun hook
 func NewHandler(cmd *cobra.Command) handlers.Handler {
 	fh := cli.NewFlagHelper(cmd)
+
+	// Non-profile flags
 	host := fh.GetOptionalString("host")
 	tlsNoVerify := fh.GetOptionalBool("tls-no-verify")
 	withClientCreds := fh.GetOptionalString("with-client-creds")
@@ -73,9 +75,11 @@ func NewHandler(cmd *cobra.Command) handlers.Handler {
 
 	// if global flags are set then validate and create a temporary profile in memory
 	var cp *profiles.ProfileStore
-	if host != "" || withClientCreds != "" || withClientCredsFile != "" {
-		err := errors.New("when using global flags --host, --with-client-creds, or --with-client-creds-file, " +
-			"profiles will not be used and all required flags must be set")
+	if host != "" || tlsNoVerify || withClientCreds != "" || withClientCredsFile != "" {
+		err := errors.New(
+			"when using global flags --host, --tls-no-verify, --with-client-creds, or --with-client-creds-file, " +
+				"profiles will not be used and all required flags must be set",
+		)
 
 		// host must be set
 		if host == "" {
@@ -168,6 +172,12 @@ func init() {
 		rootCmd.GetDocFlag("version").Name,
 		rootCmd.GetDocFlag("version").DefaultAsBool(),
 		rootCmd.GetDocFlag("version").Description,
+	)
+
+	RootCmd.PersistentFlags().String(
+		rootCmd.GetDocFlag("profile").Name,
+		rootCmd.GetDocFlag("profile").Default,
+		rootCmd.GetDocFlag("profile").Description,
 	)
 
 	RootCmd.PersistentFlags().String(

--- a/docs/man/_index.md
+++ b/docs/man/_index.md
@@ -7,6 +7,9 @@ command:
     - name: version
       description: show version
       default: false
+    - name: profile
+      description: profile to use for interacting with the platform
+      default: 
     - name: host
       description: Hostname of the platform (i.e. https://localhost)
       default:

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -3,9 +3,11 @@ package auth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"time"
@@ -190,7 +192,16 @@ func GetTokenWithClientCreds(ctx context.Context, endpoint string, clientId stri
 		return nil, err
 	}
 
-	rp, err := oidcrp.NewRelyingPartyOIDC(ctx, pc.issuer, clientId, clientSecret, "", []string{"email"})
+	// Create a new HTTP client with the ability to skip TLS verification
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: tlsNoVerify,
+			},
+		},
+	}
+
+	rp, err := oidcrp.NewRelyingPartyOIDC(ctx, pc.issuer, clientId, clientSecret, "", []string{"email"}, oidcrp.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+func NewHttpClient(tlsNoVerify bool) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: tlsNoVerify,
+			},
+		},
+	}
+}


### PR DESCRIPTION
With otdfctl leveraging zitadel module for oidc outside the scope of the sdk otdfctl needs to create a custom http client to ignore tls verification. 