### PR TITLE
feat(ci): reusable platform composite action in e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,6 @@ jobs:
         uses: opentdf/platform/test/start-up-with-containers@main
         with:
           platform-ref: 'main'
-      - uses: opentdf/otdfctl/e2e@main
+      - uses: opentdf/otdfctl/e2e@feat/reusable-plat
         with:
           otdfctl-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start up the platform with deps and containers
-        uses: opentdf/platform/test/start-up-with-containers@fix/reusable-ci
+        uses: opentdf/platform/test/start-up-with-containers@main
         with:
           platform-ref: 'main'
       - uses: opentdf/otdfctl/e2e@feat/reusable-plat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,6 @@ jobs:
         uses: opentdf/platform/test/start-up-with-containers@main
         with:
           platform-ref: 'main'
-      - uses: opentdf/otdfctl/e2e@feat/reusable-plat
+      - uses: opentdf/otdfctl/e2e@main
         with:
           otdfctl-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,10 @@ jobs:
     name: e2e tests
     runs-on: ubuntu-latest
     steps:
-      - uses: opentdf/otdfctl/e2e@main
+      - name: Start up the platform with deps and containers
+        uses: opentdf/platform/.github/workflows/start-up-with-containers@feat/reusable-startup
         with:
           platform-ref: 'main'
+      - uses: opentdf/otdfctl/e2e@main
+        with:
           otdfctl-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start up the platform with deps and containers
-        uses: opentdf/platform/test/start-up-with-containers@feat/reusable-startup
+        uses: opentdf/platform/test/start-up-with-containers@main
         with:
           platform-ref: 'main'
       - uses: opentdf/otdfctl/e2e@feat/reusable-plat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start up the platform with deps and containers
-        uses: opentdf/platform/.github/workflows/start-up-with-containers@feat/reusable-startup
+        uses: opentdf/platform/test/start-up-with-containers@feat/reusable-startup
         with:
           platform-ref: 'main'
       - uses: opentdf/otdfctl/e2e@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start up the platform with deps and containers
-        uses: opentdf/platform/test/start-up-with-containers@main
+        uses: opentdf/platform/test/start-up-with-containers@fix/reusable-ci
         with:
           platform-ref: 'main'
       - uses: opentdf/otdfctl/e2e@feat/reusable-plat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,6 @@ jobs:
         uses: opentdf/platform/test/start-up-with-containers@feat/reusable-startup
         with:
           platform-ref: 'main'
-      - uses: opentdf/otdfctl/e2e@main
+      - uses: opentdf/otdfctl/e2e@feat/reusable-plat
         with:
           otdfctl-ref: ${{ github.event.pull_request.head.sha }}

--- a/e2e/action.yaml
+++ b/e2e/action.yaml
@@ -1,15 +1,6 @@
 name: 'end-to-end'
 description: 'Run end-to-end tests for the otdfctl CLI'
 inputs:
-  # Known issue: boolean defaults are treated as strings [https://stackoverflow.com/questions/76292948/github-action-boolean-input-with-default-value]
-  platform-is-running:
-    required: false
-    default: 'false'
-    description: 'If false, spin up the platform and its resources'
-  platform-ref:
-    required: false
-    description: 'The ref to check out for the platform'
-    default: 'main'
   otdfctl-ref:
     required: false
     description: 'The ref to check out for the otdfctl CLI'
@@ -18,83 +9,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Report on the run context
-      shell: bash
-      run: |
-        if [ ${{ inputs.platform-is-running }} == 'true' ]; then
-          echo "Platform is already running"
-        else
-            echo "Platform will be checked out at '${{ inputs.platform-ref }}' and spun up"
-        fi
-        echo "Testing otdfctl CLI from '${{ inputs.otdfctl-ref }}'"
     - name: Check out otdfctl CLI
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       with:
         repository: opentdf/otdfctl
         ref: ${{ inputs.otdfctl-ref }}
         path: otdfctl
-      # Spin up the platform IFF it's not already running in the current workflow context
-    - name: Check out platform
-      if: ${{ inputs.platform-is-running == 'false' }}
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      with:
-        repository: opentdf/platform
-        path: platform
-        ref: ${{ inputs.platform-ref }}
-    - name: Set up go (platform's go version)
-      id: setup-go
-      if: ${{ inputs.platform-is-running == 'false' }}
-      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
-      with:
-        go-version-file: 'platform/service/go.mod'
-        check-latest: false
-        cache-dependency-path: |
-          platform/service/go.sum
-          platform/protocol/go/go.sum
-          platform/sdk/go.sum
-    - name: Provide the platform with keys
-      shell: bash
-      if: ${{ inputs.platform-is-running == 'false' }}
-      run: |
-        .github/scripts/init-temp-keys.sh
-        cp opentdf-dev.yaml opentdf.yaml
-      working-directory: platform
-    - name: Trust the generated certs
-      if: ${{ inputs.platform-is-running == 'false' }}
-      shell: bash
-      run: |
-        sudo chmod -R 777 ./keys
-        sudo apt-get install -y ca-certificates
-        sudo cp ./keys/localhost.crt /usr/local/share/ca-certificates
-        sudo update-ca-certificates
-      working-directory: platform
-    - name: Spin up platform's containerized resources
-      if: ${{ inputs.platform-is-running == 'false' }}
-      shell: bash
-      run: docker compose up -d --wait --wait-timeout 240
-      working-directory: platform
-    - name: Provision realms/clients/users into idP
-      if: ${{ inputs.platform-is-running == 'false' }}
-      shell: bash
-      run: go run ./service provision keycloak
-      working-directory: platform
-    - name: Provision test fixture policy
-      if: ${{ inputs.platform-is-running == 'false' }}
-      shell: bash
-      run: go run ./service provision fixtures
-      working-directory: platform
-    - name: Start platform server in background
-      if: ${{ inputs.platform-is-running == 'false' }}
-      uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635
-      with:
-        run: >
-          go build -o opentdf -v service/main.go
-          && .github/scripts/watch.sh opentdf.yaml ./opentdf start
-        wait-on: |
-          tcp:localhost:8080
-        log-output-if: true
-        wait-for: 90s
-        working-directory: platform
 
     # Build the CLI and run tests
     - name: Set up go (CLI version, if needed)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentdf/otdfctl
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/adrg/frontmatter v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,6 @@ github.com/opentdf/platform/lib/ocrypto v0.1.5 h1:Gv5dAmZEVQeD9w1Fg9fix8gdZIsPDH
 github.com/opentdf/platform/lib/ocrypto v0.1.5/go.mod h1:ne+l8Q922OdzA0xesK3XJmfECBnn5vLSGYU3/3OhiHM=
 github.com/opentdf/platform/protocol/go v0.2.14 h1:0wqKDVTpuPICyH37ecKxR2+tZNsgXV8TfdzlbQ3ovrA=
 github.com/opentdf/platform/protocol/go v0.2.14/go.mod h1:WqDcnFQJb0v8ivRQPidbehcL8ils5ZSZYXkuv0nyvsI=
-github.com/opentdf/platform/sdk v0.3.10 h1:WoPtM6IcwwDIEqCcLq2jb6pd15bFXmEDaju9MKd6JtM=
-github.com/opentdf/platform/sdk v0.3.10/go.mod h1:XqFivuo4tcqxGwJF9ORnLB3S5bjrgJwiaj6BAJUXJXg=
 github.com/opentdf/platform/sdk v0.3.12 h1:1WBiogmIoFseG4xj3j0NXpcQz7a8huHos2KKwaFpYDs=
 github.com/opentdf/platform/sdk v0.3.12/go.mod h1:XqFivuo4tcqxGwJF9ORnLB3S5bjrgJwiaj6BAJUXJXg=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -198,6 +198,7 @@ func GetTokenWithClientCreds(ctx context.Context, endpoint string, clientId stri
 	if err != nil {
 		return nil, err
 	}
+
 	return oidcrp.ClientCredentials(ctx, rp, url.Values{})
 }
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -198,7 +198,6 @@ func GetTokenWithClientCreds(ctx context.Context, endpoint string, clientId stri
 	if err != nil {
 		return nil, err
 	}
-
 	return oidcrp.ClientCredentials(ctx, rp, url.Values{})
 }
 


### PR DESCRIPTION
Resolves #371 
Unblocked by https://github.com/opentdf/platform/issues/1530

Chicken and egg problem at the moment:
When referencing the changes to _not run the platform_ in `otdfctl/e2e/action.yaml` by referencing the branch for the run, we [have a passing job](https://github.com/opentdf/otdfctl/actions/runs/10779107822/job/29891886738?pr=369) but we need to merge this in to have it pass compatibly.

Evidence the `platform` can run the tests on a PR branch there against `main` in `otdfctl`: https://github.com/opentdf/platform/actions/runs/10780058471/job/29894940400?pr=1526