### PR TITLE
feat(core): Update Resource Mapping delete to use get before delete for cli output

### DIFF
--- a/cmd/policy-resourceMappings.go
+++ b/cmd/policy-resourceMappings.go
@@ -143,7 +143,12 @@ func policy_deleteResourceMapping(cmd *cobra.Command, args []string) {
 		cli.ConfirmAction(cli.ActionDelete, "resource-mapping", id, false)
 	}
 
-	resourceMapping, err := h.DeleteResourceMapping(id)
+	resourceMapping, err := h.GetResourceMapping(id)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to get resource mapping for delete (%s)", id), err)
+	}
+
+	_, err = h.DeleteResourceMapping(id)
 	if err != nil {
 		cli.ExitWithError(fmt.Sprintf("Failed to delete resource mapping (%s)", id), err)
 	}


### PR DESCRIPTION
Due to changes made in https://github.com/opentdf/platform/pull/1422 to only return an object with the ID for delete operations, we need to update the otdfctl Resource Mapping delete operation to make a Get request from the DB before deletion of the record.  The object returned from the Get is then used for the user-friendly CLI output of the whole object. 