### PR TITLE
fix(core): kasr creation JSON example

### DIFF
--- a/docs/man/policy/kas-registry/create.md
+++ b/docs/man/policy/kas-registry/create.md
@@ -36,21 +36,21 @@ can be retrieved for the registered KAS under the `remote` key, such as `https:/
 
 ### Cached
 
-```json5
+```json
 {
-  cached: {
+  "cached": {
     // One or more known public keys for the KAS
-    keys: [
+    "keys": [
       {
         // x509 ASN.1 content in PEM envelope, usually
-        pem: '<your PEM certificate>',
+        "pem": "<your PEM certificate>",
         // key identifier
-        kid: '<your key id>',
+        "kid": "<your key id>",
         // key algorithm (see table below)
-        alg: 1,
-      },
-    ],
-  },
+        "alg": 1
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
change markdown example code block from json5 to json in KASR create help manual for easier copy/paste into the CLI