### PR TITLE
chore(ci): Enable skew testing with xtest

### DIFF
--- a/.github/release-please.json
+++ b/.github/release-please.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+    "release-type": "go",
+    "bump-minor-pre-major": true,
+    "bump-patch-for-minor-pre-major": true,
+    "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
+    "packages": {
+        ".": {}
+    },
+    "extra-files": [
+        {
+            "type": "generic",
+            "path": "pkg/config/config.go"
+        }
+    ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,4 +67,6 @@ jobs:
       - unit
     uses: opentdf/tests/.github/workflows/xtest.yml@main
     with:
-      otdfctl-ref: ${{ github.ref }}
+      otdfctl-ref: ${{ github.ref }} lts
+      platform-ref: main lts
+      focus-sdk: go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,3 +60,11 @@ jobs:
       - uses: opentdf/otdfctl/e2e@main
         with:
           otdfctl-ref: ${{ github.event.pull_request.head.sha }}
+
+  platform-xtest:
+    needs:
+      - golangci
+      - unit
+    uses: opentdf/tests/.github/workflows/xtest.yml@main
+    with:
+      otdfctl-ref: ${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f
         id: release
         with:
+          config-file: .github/release-please.json
           token: ${{ steps.generate_token.outputs.token }}
           release-type: go
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ var (
 	// config file naming and in the profile store
 	AppName = "otdfctl"
 
-	Version   = "0.0.0"
+	Version   = "0.20.0" // x-release-please-version
 	BuildTime = "1970-01-01T00:00:00Z"
 	CommitSha = "0000000"
 


### PR DESCRIPTION
- Also, moves the version number to release-please control instead of requiring a build config. This will allow version-based selection of features in skew test code, which will simplify skipping tests for legacy builds from source as new features are added to xtest