### PR TITLE
chore(ci): Enable testing against old releases

### DIFF
--- a/.github/release-please.json
+++ b/.github/release-please.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+    "release-type": "go",
+    "bump-minor-pre-major": true,
+    "bump-patch-for-minor-pre-major": true,
+    "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
+    "packages": {
+        ".": {}
+    },
+    "extra-files": [
+        {
+            "type": "generic",
+            "path": "pkg/config/config.go"
+        }
+    ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,3 +62,11 @@ jobs:
       - uses: opentdf/otdfctl/e2e@main
         with:
           otdfctl-ref: ${{ github.event.pull_request.head.sha }}
+
+  platform-xtest:
+    needs:
+      - golangci
+      - unit
+    uses: opentdf/tests/.github/workflows/xtest.yml@main
+    with:
+      otdfctl-ref: ${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,4 +69,6 @@ jobs:
       - unit
     uses: opentdf/tests/.github/workflows/xtest.yml@main
     with:
-      otdfctl-ref: ${{ github.ref }}
+      otdfctl-ref: ${{ github.ref }} lts
+      platform-ref: main lts
+      focus-sdk: go

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         id: release
         with:
+          config-file: .github/release-please.json
           token: ${{ steps.generate_token.outputs.token }}
           release-type: go
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ var (
 	// config file naming and in the profile store
 	AppName = "otdfctl"
 
-	Version   = "0.0.0"
+	Version   = "0.20.0" // x-release-please-version
 	BuildTime = "1970-01-01T00:00:00Z"
 	CommitSha = "0000000"
 


### PR DESCRIPTION
- Adds xtest workflow, for testing against LTS version of otdfctl and platform backend
- Lets release-please set the baked-in version field, to allow easier builds from source and as a library
- Notably, this slightly improves error output in the xtest logs