### PR TITLE
fix(ci): ci job should run on changes to GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - '**/*.yaml'
+      - '!.github/**/*.yaml' 
       - '**/*.md'
       - LICENSE
       - CODEOWNERS

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
           version: v2.0.2
           # Optional: golangci-lint command line arguments.
           args: --timeout=10m
+          only-new-issues: true
   unit:
     name: unit tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
This prevents failing to detect a major breaking change in a github action dependency bump from dependabot, as happened recently with the `golangci-lint` action upgrading to require v2.