### PR TITLE
fix(main): Pass the full url when building the sdk object

### DIFF
--- a/pkg/handlers/sdk.go
+++ b/pkg/handlers/sdk.go
@@ -95,7 +95,7 @@ func New(opts ...handlerOptsFunc) (Handler, error) {
 		o.sdkOpts = append(o.sdkOpts, sdk.WithInsecurePlaintextConn())
 	}
 
-	s, err := sdk.New(u.Host, o.sdkOpts...)
+	s, err := sdk.New(u.String(), o.sdkOpts...)
 	if err != nil {
 		return Handler{}, err
 	}


### PR DESCRIPTION
include the scheme when passing the url to the sdk constructor