### PR TITLE
fix(main): Use cmd.Context for resource mapping group commands

### DIFF
--- a/cmd/policy-resourceMappingGroups.go
+++ b/cmd/policy-resourceMappingGroups.go
@@ -22,7 +22,7 @@ func policyCreateResourceMappingGroup(cmd *cobra.Command, args []string) {
 	name := c.Flags.GetRequiredString("name")
 	metadataLabels = c.Flags.GetStringSlice("label", metadataLabels, cli.FlagsStringSliceOptions{Min: 0})
 
-	resourceMappingGroup, err := h.CreateResourceMappingGroup(nsID, name, getMetadataMutable(metadataLabels))
+	resourceMappingGroup, err := h.CreateResourceMappingGroup(cmd.Context(), nsID, name, getMetadataMutable(metadataLabels))
 	if err != nil {
 		cli.ExitWithError("Failed to create resource mapping group", err)
 	}
@@ -45,7 +45,7 @@ func policyGetResourceMappingGroup(cmd *cobra.Command, args []string) {
 
 	id := c.Flags.GetRequiredID("id")
 
-	resourceMappingGroup, err := h.GetResourceMappingGroup(id)
+	resourceMappingGroup, err := h.GetResourceMappingGroup(cmd.Context(), id)
 	if err != nil {
 		cli.ExitWithError(fmt.Sprintf("Failed to get resource mapping group (%s)", id), err)
 	}
@@ -109,7 +109,7 @@ func policyUpdateResourceMappingGroup(cmd *cobra.Command, args []string) {
 	name := c.Flags.GetOptionalString("name")
 	metadataLabels = c.Flags.GetStringSlice("label", metadataLabels, cli.FlagsStringSliceOptions{Min: 0})
 
-	resourceMappingGroup, err := h.UpdateResourceMappingGroup(id, nsID, name, getMetadataMutable(metadataLabels), getMetadataUpdateBehavior())
+	resourceMappingGroup, err := h.UpdateResourceMappingGroup(cmd.Context(), id, nsID, name, getMetadataMutable(metadataLabels), getMetadataUpdateBehavior())
 	if err != nil {
 		cli.ExitWithError(fmt.Sprintf("Failed to update resource mapping group (%s)", id), err)
 	}
@@ -135,12 +135,12 @@ func policyDeleteResourceMappingGroup(cmd *cobra.Command, args []string) {
 
 	cli.ConfirmAction(cli.ActionDelete, "resource-mapping-group", id, force)
 
-	resourceMappingGroup, err := h.GetResourceMappingGroup(id)
+	resourceMappingGroup, err := h.GetResourceMappingGroup(cmd.Context(), id)
 	if err != nil {
 		cli.ExitWithError(fmt.Sprintf("Failed to get resource mapping group for delete (%s)", id), err)
 	}
 
-	_, err = h.DeleteResourceMappingGroup(id)
+	_, err = h.DeleteResourceMappingGroup(cmd.Context(), id)
 	if err != nil {
 		cli.ExitWithError(fmt.Sprintf("Failed to delete resource mapping group (%s)", id), err)
 	}

--- a/pkg/handlers/resourceMappingGroups.go
+++ b/pkg/handlers/resourceMappingGroups.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Creates and returns the created resource mapping
-func (h *Handler) CreateResourceMappingGroup(namespaceID string, name string, metadata *common.MetadataMutable) (*policy.ResourceMappingGroup, error) {
-	res, err := h.sdk.ResourceMapping.CreateResourceMappingGroup(context.Background(), &resourcemapping.CreateResourceMappingGroupRequest{
+func (h *Handler) CreateResourceMappingGroup(ctx context.Context, namespaceID string, name string, metadata *common.MetadataMutable) (*policy.ResourceMappingGroup, error) {
+	res, err := h.sdk.ResourceMapping.CreateResourceMappingGroup(ctx, &resourcemapping.CreateResourceMappingGroupRequest{
 		NamespaceId: namespaceID,
 		Name:        name,
 		Metadata:    metadata,
@@ -19,11 +19,11 @@ func (h *Handler) CreateResourceMappingGroup(namespaceID string, name string, me
 		return nil, err
 	}
 
-	return h.GetResourceMappingGroup(res.GetResourceMappingGroup().GetId())
+	return h.GetResourceMappingGroup(ctx, res.GetResourceMappingGroup().GetId())
 }
 
-func (h *Handler) GetResourceMappingGroup(id string) (*policy.ResourceMappingGroup, error) {
-	res, err := h.sdk.ResourceMapping.GetResourceMappingGroup(context.Background(), &resourcemapping.GetResourceMappingGroupRequest{
+func (h *Handler) GetResourceMappingGroup(ctx context.Context, id string) (*policy.ResourceMappingGroup, error) {
+	res, err := h.sdk.ResourceMapping.GetResourceMappingGroup(ctx, &resourcemapping.GetResourceMappingGroupRequest{
 		Id: id,
 	})
 	if err != nil {
@@ -49,8 +49,8 @@ func (h *Handler) ListResourceMappingGroups(ctx context.Context, limit, offset i
 
 // TODO: verify updation behavior
 // Updates and returns the updated resource mapping
-func (h *Handler) UpdateResourceMappingGroup(id string, namespaceID string, name string, metadata *common.MetadataMutable, behavior common.MetadataUpdateEnum) (*policy.ResourceMappingGroup, error) {
-	_, err := h.sdk.ResourceMapping.UpdateResourceMappingGroup(context.Background(), &resourcemapping.UpdateResourceMappingGroupRequest{
+func (h *Handler) UpdateResourceMappingGroup(ctx context.Context, id string, namespaceID string, name string, metadata *common.MetadataMutable, behavior common.MetadataUpdateEnum) (*policy.ResourceMappingGroup, error) {
+	_, err := h.sdk.ResourceMapping.UpdateResourceMappingGroup(ctx, &resourcemapping.UpdateResourceMappingGroupRequest{
 		Id:                     id,
 		NamespaceId:            namespaceID,
 		Name:                   name,
@@ -61,11 +61,11 @@ func (h *Handler) UpdateResourceMappingGroup(id string, namespaceID string, name
 		return nil, err
 	}
 
-	return h.GetResourceMappingGroup(id)
+	return h.GetResourceMappingGroup(ctx, id)
 }
 
-func (h *Handler) DeleteResourceMappingGroup(id string) (*policy.ResourceMappingGroup, error) {
-	resp, err := h.sdk.ResourceMapping.DeleteResourceMappingGroup(context.Background(), &resourcemapping.DeleteResourceMappingGroupRequest{
+func (h *Handler) DeleteResourceMappingGroup(ctx context.Context, id string) (*policy.ResourceMappingGroup, error) {
+	resp, err := h.sdk.ResourceMapping.DeleteResourceMappingGroup(ctx, &resourcemapping.DeleteResourceMappingGroupRequest{
 		Id: id,
 	})
 	if err != nil {


### PR DESCRIPTION
pass the context from the command