### PR TITLE
chore(ci): Let xtest validate against latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,6 @@ jobs:
       - unit
     uses: opentdf/tests/.github/workflows/xtest.yml@main
     with:
-      otdfctl-ref: ${{ github.ref }} lts
+      otdfctl-ref: ${{ github.ref }} latest
       platform-ref: main lts
       focus-sdk: go


### PR DESCRIPTION
- skips currently failing lts (0.15.0) tag