### PR TITLE
feat(core): Registered Resources - action attribute values update confirmation

### DIFF
--- a/cmd/policy-registeredResources.go
+++ b/cmd/policy-registeredResources.go
@@ -334,8 +334,16 @@ func policyUpdateRegisteredResourceValue(cmd *cobra.Command, args []string) {
 	value := c.Flags.GetOptionalString("value")
 	actionAttributeValues = c.Flags.GetStringSlice("action-attribute-value", actionAttributeValues, cli.FlagsStringSliceOptions{Min: 0})
 	metadataLabels = c.Flags.GetStringSlice("label", metadataLabels, cli.FlagsStringSliceOptions{Min: 0})
+	force := c.Flags.GetOptionalBool("force")
 
 	parsedActionAttributeValues := parseActionAttributeValueArgs(actionAttributeValues)
+
+	// only confirm if new action attribute values provided
+	if len(parsedActionAttributeValues) > 0 {
+		cli.ConfirmActionSubtext(cli.ActionUpdate, "registered resource value", id,
+			"All existing action attribute values will be replaced with the new ones provided.",
+			force)
+	}
 
 	updated, err := h.UpdateRegisteredResourceValue(
 		cmd.Context(),
@@ -590,6 +598,11 @@ func init() {
 		updateValueDoc.GetDocFlag("action-attribute-value").Description,
 	)
 	injectLabelFlags(&updateValueDoc.Command, true)
+	updateValueDoc.Flags().Bool(
+		updateValueDoc.GetDocFlag("force").Name,
+		false,
+		updateValueDoc.GetDocFlag("force").Description,
+	)
 
 	deleteValueDoc := man.Docs.GetCommand("policy/registered-resources/values/delete",
 		man.WithRun(policyDeleteRegisteredResourceValue),

--- a/docs/man/policy/registered-resources/values/update.md
+++ b/docs/man/policy/registered-resources/values/update.md
@@ -19,6 +19,8 @@ command:
       description: "Optional metadata 'labels' in the format: key=value"
       shorthand: l
       default: ''
+    - name: force
+      description: Force update without interactive confirmation
 ---
 
 Update any or all of the `value`, action attribute values, and metadata labels for a Registered Resource Value.

--- a/e2e/registered-resources.bats
+++ b/e2e/registered-resources.bats
@@ -370,7 +370,7 @@ teardown_file() {
   created_id=$(echo "$output" | grep Id | awk -F'│' '{print $3}' | xargs)
 
   # force replace labels
-  run_otdfctl_reg_res_values update --id "$created_id" -l key=other --force-replace-labels --force
+  run_otdfctl_reg_res_values update --id "$created_id" -l key=other --force-replace-labels
     assert_success
     assert_line --regexp "Id.*$created_id"
     assert_line --regexp "Value.*test_update_rr_val"
@@ -380,7 +380,7 @@ teardown_file() {
     refute_output --regexp "Labels.*test: true"
 
   # renamed
-  run_otdfctl_reg_res_values update --id "$created_id" --value test_renamed_rr_val --force
+  run_otdfctl_reg_res_values update --id "$created_id" --value test_renamed_rr_val
     assert_success
     assert_line --regexp "Id.*$created_id"
     assert_line --regexp "Value.*test_renamed_rr_val"

--- a/e2e/registered-resources.bats
+++ b/e2e/registered-resources.bats
@@ -370,7 +370,7 @@ teardown_file() {
   created_id=$(echo "$output" | grep Id | awk -F'│' '{print $3}' | xargs)
 
   # force replace labels
-  run_otdfctl_reg_res_values update --id "$created_id" -l key=other --force-replace-labels
+  run_otdfctl_reg_res_values update --id "$created_id" -l key=other --force-replace-labels --force
     assert_success
     assert_line --regexp "Id.*$created_id"
     assert_line --regexp "Value.*test_update_rr_val"
@@ -380,7 +380,7 @@ teardown_file() {
     refute_output --regexp "Labels.*test: true"
 
   # renamed
-  run_otdfctl_reg_res_values update --id "$created_id" --value test_renamed_rr_val
+  run_otdfctl_reg_res_values update --id "$created_id" --value test_renamed_rr_val --force
     assert_success
     assert_line --regexp "Id.*$created_id"
     assert_line --regexp "Value.*test_renamed_rr_val"
@@ -391,7 +391,7 @@ teardown_file() {
     [ "$(echo "$output" | jq -r 'any(.action_attribute_values[]; .action.id == "'"$READ_ACTION_ID"'" and .action.name == "'"$READ_ACTION_NAME"'" and .attribute_value.id == "'"$ATTR_VAL_1_ID"'" and .attribute_value.fqn == "'"$ATTR_VAL_1_FQN"'")')" = "true" ]
 
   # update action attribute values
-  run_otdfctl_reg_res_values update --id "$created_id" --action-attribute-value "\"$READ_ACTION_NAME;$ATTR_VAL_1_FQN\"" --action-attribute-value "\"$CUSTOM_ACTION_ID;$ATTR_VAL_2_ID\"" --json
+  run_otdfctl_reg_res_values update --id "$created_id" --action-attribute-value "\"$READ_ACTION_NAME;$ATTR_VAL_1_FQN\"" --action-attribute-value "\"$CUSTOM_ACTION_ID;$ATTR_VAL_2_ID\"" --force --json
     assert_success
     [ "$(echo "$output" | jq -r '.id')" = "$created_id" ]
     [ "$(echo "$output" | jq -r 'any(.action_attribute_values[]; .action.id == "'"$READ_ACTION_ID"'" and .action.name == "'"$READ_ACTION_NAME"'" and .attribute_value.id == "'"$ATTR_VAL_1_ID"'" and .attribute_value.fqn == "'"$ATTR_VAL_1_FQN"'")')" = "true" ]

--- a/pkg/cli/confirm.go
+++ b/pkg/cli/confirm.go
@@ -22,6 +22,26 @@ const (
 	InputNameFQNUpdated = "deprecated fully qualified name (FQN) being altered"
 )
 
+func ConfirmActionSubtext(action, resource, id, subtext string, force bool) {
+	if force {
+		return
+	}
+	var confirm bool
+	err := huh.NewConfirm().
+		Title(fmt.Sprintf("Are you sure you want to %s %s:\n\n\t%s\n\n%s", action, resource, id, subtext)).
+		Affirmative("yes").
+		Negative("no").
+		Value(&confirm).
+		Run()
+	if err != nil {
+		ExitWithError("Confirmation prompt failed", err)
+	}
+
+	if !confirm {
+		ExitWithError("Aborted", nil)
+	}
+}
+
 func ConfirmAction(action, resource, id string, force bool) {
 	if force {
 		return

--- a/pkg/cli/confirm.go
+++ b/pkg/cli/confirm.go
@@ -27,8 +27,14 @@ func ConfirmActionSubtext(action, resource, id, subtext string, force bool) {
 		return
 	}
 	var confirm bool
+	title := fmt.Sprintf("Are you sure you want to %s %s:\n\n\t%s", action, resource, id)
+	if subtext != "" {
+		// since we don't return an error to stay consistent with the original function,
+		// only append the subtext if populated
+		title += fmt.Sprintf("\n\n%s", subtext)
+	}
 	err := huh.NewConfirm().
-		Title(fmt.Sprintf("Are you sure you want to %s %s:\n\n\t%s\n\n%s", action, resource, id, subtext)).
+		Title(title).
 		Affirmative("yes").
 		Negative("no").
 		Value(&confirm).


### PR DESCRIPTION
Adds a confirmation prompt to the registered resource values update command to notify users that any existing action attribute values will be replaced by any new ones provided to the command. Can be ignored using a new `--force` flag added in this PR as well.