### PR TITLE
feat(core): Assign certificate to namespace

### DIFF
--- a/cmd/policy-certificates.go
+++ b/cmd/policy-certificates.go
@@ -1,0 +1,364 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/evertras/bubble-table/table"
+	"github.com/opentdf/otdfctl/pkg/cli"
+	"github.com/opentdf/otdfctl/pkg/handlers"
+	"github.com/spf13/cobra"
+)
+
+var (
+	policy_certificatesCmd = &cobra.Command{
+		Use:   "certificates",
+		Short: "Manage certificates for namespaces",
+		Long:  "Commands to create, list, and manage certificates for attribute namespaces",
+	}
+
+	policy_certificatesListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List certificates for a namespace",
+		Long:  "List all root certificates assigned to a namespace",
+		Run:   policy_listNamespaceCertificates,
+	}
+
+	policy_certificatesGetCmd = &cobra.Command{
+		Use:   "get",
+		Short: "Get a certificate by ID",
+		Long:  "Retrieve details of a specific certificate",
+		Run:   policy_getCertificate,
+	}
+
+	policy_certificatesShowCmd = &cobra.Command{
+		Use:   "show",
+		Short: "Show namespace with certificates",
+		Long:  "Display a namespace and all its associated root certificates",
+		Run:   policy_showNamespaceWithCertificates,
+	}
+
+	policy_certificatesConvertCmd = &cobra.Command{
+		Use:   "convert-pem",
+		Short: "Convert PEM certificate to x5c format",
+		Long:  "Convert a PEM-encoded certificate file to x5c format (base64-encoded DER)",
+		Run:   policy_convertPEMToX5C,
+	}
+
+	policy_certificatesAssignCmd = &cobra.Command{
+		Use:   "assign",
+		Short: "Assign a certificate to a namespace",
+		Long:  "Assign a root certificate to an attribute namespace for establishing trust",
+		Run:   policy_assignCertificateToNamespace,
+	}
+
+	policy_certificatesRemoveCmd = &cobra.Command{
+		Use:   "remove",
+		Short: "Remove a certificate from a namespace",
+		Long:  "Remove a root certificate from an attribute namespace",
+		Run:   policy_removeCertificateFromNamespace,
+	}
+)
+
+func init() {
+	// List certificates for namespace
+	policy_certificatesListCmd.Flags().StringP(
+		"namespace-id",
+		"n",
+		"",
+		"Namespace ID or FQN to list certificates for",
+	)
+	if err := policy_certificatesListCmd.MarkFlagRequired("namespace-id"); err != nil {
+		panic(err)
+	}
+
+	// Get certificate
+	policy_certificatesGetCmd.Flags().StringP(
+		"id",
+		"i",
+		"",
+		"Certificate ID",
+	)
+	if err := policy_certificatesGetCmd.MarkFlagRequired("id"); err != nil {
+		panic(err)
+	}
+
+	// Show namespace with certificates
+	policy_certificatesShowCmd.Flags().StringP(
+		"namespace-id",
+		"n",
+		"",
+		"Namespace ID or FQN",
+	)
+	if err := policy_certificatesShowCmd.MarkFlagRequired("namespace-id"); err != nil {
+		panic(err)
+	}
+
+	// Convert PEM to x5c
+	policy_certificatesConvertCmd.Flags().StringP(
+		"file",
+		"f",
+		"",
+		"Path to PEM certificate file",
+	)
+	if err := policy_certificatesConvertCmd.MarkFlagRequired("file"); err != nil {
+		panic(err)
+	}
+	policy_certificatesConvertCmd.Flags().BoolP(
+		"output-pem",
+		"p",
+		false,
+		"Output as PEM format (for x5c to PEM conversion)",
+	)
+
+	// Assign certificate to namespace
+	policy_certificatesAssignCmd.Flags().StringP(
+		"namespace",
+		"n",
+		"",
+		"Namespace ID or FQN",
+	)
+	if err := policy_certificatesAssignCmd.MarkFlagRequired("namespace"); err != nil {
+		panic(err)
+	}
+	policy_certificatesAssignCmd.Flags().StringP(
+		"file",
+		"f",
+		"",
+		"Path to PEM certificate file",
+	)
+	if err := policy_certificatesAssignCmd.MarkFlagRequired("file"); err != nil {
+		panic(err)
+	}
+	injectLabelFlags(policy_certificatesAssignCmd, false)
+
+	// Remove certificate from namespace
+	policy_certificatesRemoveCmd.Flags().StringP(
+		"namespace",
+		"n",
+		"",
+		"Namespace ID or FQN",
+	)
+	if err := policy_certificatesRemoveCmd.MarkFlagRequired("namespace"); err != nil {
+		panic(err)
+	}
+	policy_certificatesRemoveCmd.Flags().StringP(
+		"certificate-id",
+		"c",
+		"",
+		"Certificate ID",
+	)
+	if err := policy_certificatesRemoveCmd.MarkFlagRequired("certificate-id"); err != nil {
+		panic(err)
+	}
+
+	// Add subcommands
+	policy_certificatesCmd.AddCommand(
+		policy_certificatesListCmd,
+		policy_certificatesGetCmd,
+		policy_certificatesShowCmd,
+		policy_certificatesConvertCmd,
+		policy_certificatesAssignCmd,
+		policy_certificatesRemoveCmd,
+	)
+
+	// Register with policy command
+	policyCmd.AddCommand(policy_certificatesCmd)
+}
+
+func policy_listNamespaceCertificates(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := NewHandler(c)
+	defer h.Close()
+
+	namespaceID := c.Flags.GetRequiredString("namespace-id")
+
+	certs, err := h.ListNamespaceCertificates(cmd.Context(), namespaceID)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to list certificates for namespace (%s)", namespaceID), err)
+	}
+
+	if len(certs) == 0 {
+		fmt.Println("No certificates found for this namespace")
+		return
+	}
+
+	t := cli.NewTable(
+		cli.NewUUIDColumn(),
+		table.NewFlexColumn("x5c_preview", "Certificate (Preview)", cli.FlexColumnWidthFour),
+	)
+
+	rows := []table.Row{}
+	for _, cert := range certs {
+		preview := cert.GetX5C()
+		if len(preview) > 50 {
+			preview = preview[:50] + "..."
+		}
+		rows = append(rows,
+			table.NewRow(table.RowData{
+				"id":          cert.GetId(),
+				"x5c_preview": preview,
+			}),
+		)
+	}
+	t = t.WithRows(rows)
+	HandleSuccess(cmd, "", t, certs)
+}
+
+func policy_getCertificate(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := NewHandler(c)
+	defer h.Close()
+
+	id := c.Flags.GetRequiredString("id")
+
+	cert, err := h.GetCertificate(cmd.Context(), id)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to get certificate (%s)", id), err)
+	}
+
+	rows := [][]string{
+		{"Id", cert.GetId()},
+		{"X5C (first 100 chars)", truncateString(cert.GetX5C(), 100)},
+	}
+	t := cli.NewTabular(rows...)
+	HandleSuccess(cmd, cert.GetId(), t, cert)
+}
+
+func policy_showNamespaceWithCertificates(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := NewHandler(c)
+	defer h.Close()
+
+	namespaceID := c.Flags.GetRequiredString("namespace-id")
+
+	ns, err := h.GetNamespaceWithCertificates(cmd.Context(), namespaceID)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to get namespace (%s)", namespaceID), err)
+	}
+
+	rows := [][]string{
+		{"Id", ns.GetId()},
+		{"Name", ns.GetName()},
+		{"FQN", ns.GetFqn()},
+		{"Certificate Count", fmt.Sprintf("%d", len(ns.GetRootCerts()))},
+	}
+	if mdRows := getMetadataRows(ns.GetMetadata()); mdRows != nil {
+		rows = append(rows, mdRows...)
+	}
+
+	// Add certificate details
+	if len(ns.GetRootCerts()) > 0 {
+		rows = append(rows, []string{"", ""}) // Spacer
+		rows = append(rows, []string{"=== Root Certificates ===", ""})
+		for i, cert := range ns.GetRootCerts() {
+			rows = append(rows, []string{fmt.Sprintf("Certificate %d ID", i+1), cert.GetId()})
+			rows = append(rows, []string{fmt.Sprintf("Certificate %d (preview)", i+1), truncateString(cert.GetX5C(), 80)})
+		}
+	}
+
+	t := cli.NewTabular(rows...)
+	HandleSuccess(cmd, ns.GetId(), t, ns)
+}
+
+func policy_convertPEMToX5C(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+
+	filePath := c.Flags.GetRequiredString("file")
+	outputPEM := cmd.Flags().Lookup("output-pem").Value.String() == "true"
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to read file (%s)", filePath), err)
+	}
+
+	if outputPEM {
+		// Convert x5c back to PEM
+		x5c := string(data)
+		pemData, err := handlers.ConvertX5CToPEM(x5c)
+		if err != nil {
+			cli.ExitWithError("Failed to convert x5c to PEM", err)
+		}
+		fmt.Println(string(pemData))
+	} else {
+		// Convert PEM to x5c
+		x5c, err := handlers.ConvertPEMToX5C(data)
+		if err != nil {
+			cli.ExitWithError("Failed to convert PEM to x5c", err)
+		}
+		fmt.Println(x5c)
+	}
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+func policy_assignCertificateToNamespace(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := NewHandler(c)
+	defer h.Close()
+
+	namespace := c.Flags.GetRequiredString("namespace")
+	filePath := c.Flags.GetRequiredString("file")
+	metadataLabels = c.Flags.GetStringSlice("label", metadataLabels, cli.FlagsStringSliceOptions{Min: 0})
+
+	// Read and convert PEM file to x5c
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to read certificate file (%s)", filePath), err)
+	}
+
+	x5c, err := handlers.ConvertPEMToX5C(data)
+	if err != nil {
+		cli.ExitWithError("Failed to convert PEM to x5c format", err)
+	}
+
+	// Get metadata from labels
+	metadata := getMetadataMutable(metadataLabels)
+	var labels map[string]string
+	if metadata != nil {
+		labels = metadata.Labels
+	}
+
+	// Assign certificate to namespace
+	resp, err := h.AssignCertificateToNamespace(cmd.Context(), namespace, x5c, labels)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to assign certificate to namespace (%s)", namespace), err)
+	}
+
+	// Prepare and display the result
+	rows := [][]string{
+		{"Namespace ID", resp.GetNamespaceCertificate().GetNamespaceId()},
+		{"Certificate ID", resp.GetNamespaceCertificate().GetCertificateId()},
+		{"Certificate (preview)", truncateString(resp.GetCertificate().GetX5C(), 80)},
+	}
+	t := cli.NewTabular(rows...)
+	HandleSuccess(cmd, namespace, t, resp)
+}
+
+func policy_removeCertificateFromNamespace(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := NewHandler(c)
+	defer h.Close()
+
+	namespace := c.Flags.GetRequiredString("namespace")
+	certID := c.Flags.GetRequiredID("certificate-id")
+
+	err := h.RemoveCertificateFromNamespace(cmd.Context(), namespace, certID)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to remove certificate (%s) from namespace (%s)", certID, namespace), err)
+	}
+
+	// Prepare and display the result
+	rows := [][]string{
+		{"Removed", "true"},
+		{"Namespace", namespace},
+		{"Certificate ID", certID},
+	}
+	t := cli.NewTabular(rows...)
+	HandleSuccess(cmd, namespace, t, nil)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,14 @@ go 1.24.0
 
 toolchain go1.24.2
 
+replace github.com/opentdf/platform/protocol/go => ../platform/protocol/go
+
+replace github.com/opentdf/platform/sdk => ../platform/sdk
+
+replace github.com/opentdf/platform/lib/ocrypto => ../platform/lib/ocrypto
+
+replace github.com/opentdf/platform/lib/flattening => ../platform/lib/flattening
+
 require (
 	github.com/adrg/frontmatter v0.2.0
 	github.com/charmbracelet/bubbles v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -234,14 +234,6 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opentdf/platform/lib/fixtures v0.3.0 h1:pgEm9ynMDIFH7Wd/lre2tfvtura8LfaV3iA1w1m7D3Q=
 github.com/opentdf/platform/lib/fixtures v0.3.0/go.mod h1:K/r0REv5MYClnkuiCxCOT1LTXbuIDP0kqixlGmPQzXc=
-github.com/opentdf/platform/lib/flattening v0.1.3 h1:IuOm/wJVXNrzOV676Ticgr0wyBkL+lVjsoSfh+WSkNo=
-github.com/opentdf/platform/lib/flattening v0.1.3/go.mod h1:Gs/T+6FGZKk9OAdz2Jf1R8CTGeNRYrq1lZGDeYT3hrY=
-github.com/opentdf/platform/lib/ocrypto v0.6.0 h1:CvluMv44dZ4vD0oLpJEoKnm4/BGJzaH8HTcTd8I0kWg=
-github.com/opentdf/platform/lib/ocrypto v0.6.0/go.mod h1:sYhoBL1bQYgQVSSNpxU13RsrE5JAk8BABT1hfr9L3j8=
-github.com/opentdf/platform/protocol/go v0.10.0 h1:7tlpFXXzOQRHAYMvBcMTYMT56wHR+6BezH2Fumjth6c=
-github.com/opentdf/platform/protocol/go v0.10.0/go.mod h1:GRycoDGDxaz91sOvGZFWVEKJLluZFg2wM3NJmhucDHo=
-github.com/opentdf/platform/sdk v0.8.0 h1:TtH1Jp3rC09X58n34L/7RwYqJWz9erNG6NF1d905M9U=
-github.com/opentdf/platform/sdk v0.8.0/go.mod h1:SUjjqOBmOiL42YUTQHjy022ixfC5GOA62Xw5DTvlu5w=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/pkg/handlers/certificates.go
+++ b/pkg/handlers/certificates.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/opentdf/platform/protocol/go/common"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/namespaces"
+)
+
+// ConvertPEMToX5C converts a PEM-encoded certificate to x5c format (base64-encoded DER)
+func ConvertPEMToX5C(pemData []byte) (string, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return "", fmt.Errorf("failed to decode PEM certificate")
+	}
+	if block.Type != "CERTIFICATE" {
+		return "", fmt.Errorf("PEM block is not a certificate, got: %s", block.Type)
+	}
+
+	// Validate it's a valid certificate
+	_, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	// Convert DER to base64 (x5c format)
+	x5c := base64.StdEncoding.EncodeToString(block.Bytes)
+	return x5c, nil
+}
+
+// ConvertX5CToPEM converts an x5c format certificate back to PEM
+func ConvertX5CToPEM(x5c string) ([]byte, error) {
+	derBytes, err := base64.StdEncoding.DecodeString(x5c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode x5c: %w", err)
+	}
+
+	// Validate it's a valid certificate
+	_, err = x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	pemBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	}
+
+	return pem.EncodeToMemory(pemBlock), nil
+}
+
+// GetCertificate retrieves a certificate by ID
+func (h Handler) GetCertificate(ctx context.Context, id string) (*policy.Certificate, error) {
+	// Note: This would require adding a GetCertificate RPC to the namespace service
+	// For now, we'll get it via the namespace
+	return nil, fmt.Errorf("GetCertificate not yet implemented in platform API")
+}
+
+// AssignCertificateToNamespace assigns a certificate to a namespace
+func (h Handler) AssignCertificateToNamespace(ctx context.Context, namespaceID, x5c string, labels map[string]string) (*namespaces.AssignCertificateToNamespaceResponse, error) {
+	metadata := &common.MetadataMutable{}
+	if labels != nil {
+		metadata.Labels = labels
+	}
+
+	req := &namespaces.AssignCertificateToNamespaceRequest{
+		NamespaceId: namespaceID,
+		X5C:         x5c,
+		Metadata:    metadata,
+	}
+
+	resp, err := h.sdk.Namespaces.AssignCertificateToNamespace(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to assign certificate to namespace [%s]: %w", namespaceID, err)
+	}
+
+	return resp, nil
+}
+
+// RemoveCertificateFromNamespace removes a certificate from a namespace
+func (h Handler) RemoveCertificateFromNamespace(ctx context.Context, namespaceID, certID string) error {
+	req := &namespaces.RemoveCertificateFromNamespaceRequest{
+		NamespaceCertificate: &namespaces.NamespaceCertificate{
+			NamespaceId:   namespaceID,
+			CertificateId: certID,
+		},
+	}
+
+	_, err := h.sdk.Namespaces.RemoveCertificateFromNamespace(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to remove certificate [%s] from namespace [%s]: %w", certID, namespaceID, err)
+	}
+
+	return nil
+}
+
+// ListNamespaceCertificates lists certificates for a namespace
+func (h Handler) ListNamespaceCertificates(ctx context.Context, namespaceID string) ([]*policy.Certificate, error) {
+	ns, err := h.GetNamespace(ctx, namespaceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace: %w", err)
+	}
+
+	return ns.GetRootCerts(), nil
+}
+
+// GetNamespaceWithCertificates retrieves a namespace with its certificates
+func (h Handler) GetNamespaceWithCertificates(ctx context.Context, identifier string) (*policy.Namespace, error) {
+	req := &namespaces.GetNamespaceRequest{}
+
+	// Try to parse as UUID first, otherwise use as FQN
+	req.Identifier = &namespaces.GetNamespaceRequest_Fqn{
+		Fqn: identifier,
+	}
+
+	resp, err := h.sdk.Namespaces.GetNamespace(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace [%s]: %w", identifier, err)
+	}
+
+	return resp.GetNamespace(), nil
+}


### PR DESCRIPTION
## Overview

Certificates can be associated with attribute namespaces to establish a chain of trust. These root certificates are stored in x5c format (base64-encoded DER) in the database and can be managed via the otdfctl CLI.

## Prerequisites

- Platform service must be running with the certificate database tables migrated https://github.com/opentdf/platform/pull/2771 

## Commands

### Convert PEM to x5c Format

Convert a PEM-encoded certificate file to x5c format:

```bash
./otdfctl policy certificates convert-pem --file /path/to/cert.pem
```

Example:
```bash
./otdfctl policy certificates convert-pem --file ../platform/keys/kas-cert.pem
```

This outputs the base64-encoded DER certificate (x5c format) to stdout.

### Show Namespace with Certificates

Display a namespace and all its associated root certificates:

```bash
./otdfctl policy certificates show \
  --namespace-id "https://example.com" \
  --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' \
  --host http://localhost:8080
```

Output:
```
SUCCESS

╭──────────────────────────┬───────────────────────────────────────────────╮
│Property                  │Value                                          │
├──────────────────────────┼───────────────────────────────────────────────┤
│Id                        │8f1d8839-2851-4bf4-8bf4-5243dbfe517d           │
│Name                      │example.com                                    │
│FQN                       │https://example.com                            │
│Certificate Count         │1                                              │
│Created At                │Wed Oct  1 15:28:25 UTC 2025                   │
│Updated At                │Wed Oct  1 15:28:25 UTC 2025                   │
│                          │                                               │
│=== Root Certificates === │                                               │
│Certificate 1 ID          │b891df13-8ad5-4c95-8add-631862207284           │
│Certificate 1 (preview)   │MIIC/TCCAeWgAwIBAgIUSMNrGBq+5ax1wDa…          │
╰──────────────────────────┴───────────────────────────────────────────────╯
```

For JSON output with full certificate data:
```bash
./otdfctl policy certificates show \
  --namespace-id "https://example.com" \
  --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' \
  --host http://localhost:8080 \
  --json
```

### Assign Certificate to Namespace

Assign a root certificate to a namespace:

```bash
./otdfctl policy certificates assign \
  --namespace "https://example.com" \
  --file ../platform/keys/kas-cert.pem \
  --label "source=kas-cert" \
  --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' \
  --host http://localhost:8080
```

Output:
```
SUCCESS

╭────────────────────────┬───────────────────────────────────────────────╮
│Namespace ID            │8f1d8839-2851-4bf4-8bf4-5243dbfe517d           │
│Certificate ID          │b891df13-8ad5-4c95-8add-631862207284           │
│Certificate (preview)   │MIIC/TCCAeWgAwIBAgIUSMNrGBq+5ax1wDa…          │
╰────────────────────────┴───────────────────────────────────────────────╯
```

### Remove Certificate from Namespace

Remove a certificate from a namespace:

```bash
./otdfctl policy certificates remove \
  --namespace "https://example.com" \
  --certificate-id "b891df13-8ad5-4c95-8add-631862207284" \
  --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' \
  --host http://localhost:8080
```

Output:
```
SUCCESS

╭────────────────┬───────────────────────────────────────────────╮
│Removed         │true                                           │
│Namespace       │https://example.com                            │
│Certificate ID  │b891df13-8ad5-4c95-8add-631862207284           │
╰────────────────┴───────────────────────────────────────────────╯
```

### List Certificates for a Namespace

List all certificates assigned to a namespace:

```bash
./otdfctl policy certificates list \
  --namespace-id "https://example.com" \
  --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' \
  --host http://localhost:8080
```

Output:
```
  SUCCESS   Found certificates list

╭─────────────────────────────────────────┬────────────────────────────────╮
│ID                                       │Certificate (Preview)           │
├─────────────────────────────────────────┼────────────────────────────────┤
│b891df13-8ad5-4c95-8add-631862207284     │MIIC/TCCAeWgAwIBAgIUSMNrGBq…   │
╰─────────────────────────────────────────┴────────────────────────────────╯
```

## Database Operations (Testing Only)

For testing purposes, certificates can also be added directly via database operations:

```sql
-- Insert a certificate
INSERT INTO opentdf_policy.certificates (x5c, metadata)
VALUES ('MIIC/TCCAeWg...', '{"labels": {"source": "kas-cert"}}')
RETURNING id;

-- Assign certificate to namespace
INSERT INTO opentdf_policy.attribute_namespace_certificates (namespace_id, certificate_id)
VALUES (
    (SELECT id FROM opentdf_policy.attribute_namespaces WHERE name = 'example.com'),
    '<certificate-id>'
);

-- Remove certificate from namespace
DELETE FROM opentdf_policy.attribute_namespace_certificates
WHERE namespace_id = '<namespace-id>' AND certificate_id = '<certificate-id>';

-- Delete certificate
DELETE FROM opentdf_policy.certificates WHERE id = '<certificate-id>';
```

Note: For production use, always use the `otdfctl` CLI commands instead of direct database operations.

## Implementation Details

### Database Schema

Two tables support certificate management:

1. **certificates** - Stores certificate data
   - `id` (UUID) - Primary key
   - `x5c` (TEXT) - Base64-encoded DER certificate
   - `metadata` (JSONB) - Optional metadata
   - `created_at`, `updated_at` - Timestamps

2. **attribute_namespace_certificates** - Junction table
   - `namespace_id` (UUID) - Foreign key to namespaces
   - `certificate_id` (UUID) - Foreign key to certificates
   - Composite primary key on both columns
   - CASCADE deletion on both foreign keys

### Code Structure

- **Handler**: `/pkg/handlers/certificates.go`
  - `ConvertPEMToX5C()` - Converts PEM to x5c format
  - `ConvertX5CToPEM()` - Converts x5c to PEM format
  - `ListNamespaceCertificates()` - Lists certificates for a namespace
  - `GetNamespaceWithCertificates()` - Retrieves namespace with certificates

- **Commands**: `/cmd/policy-certificates.go`
  - `policy certificates convert-pem` - PEM/x5c conversion
  - `policy certificates assign` - Assign certificate to namespace
  - `policy certificates remove` - Remove certificate from namespace
  - `policy certificates list` - List certificates
  - `policy certificates show` - Show namespace with certificates
  - `policy certificates get` - Get certificate by ID (placeholder)

### Platform Integration

The implementation uses the local platform repository via go.mod replace directives:

```go
replace github.com/opentdf/platform/protocol/go => ../platform/protocol/go
replace github.com/opentdf/platform/sdk => ../platform/sdk
```

This ensures otdfctl uses the latest Certificate proto definition from the local platform repository.

## Platform RPC Endpoints

The following RPC endpoints have been implemented in the namespace service:

- `AssignCertificateToNamespace` - Create and assign certificate to namespace ✅
- `RemoveCertificateFromNamespace` - Remove certificate from namespace ✅
- `GetNamespace` - Returns namespace with `rootCerts` field populated ✅

## Future Enhancements

The following features could be added in the future:

- `GetCertificate` - Get individual certificate details (currently can only view via namespace)

## Testing

Example workflow for testing certificate functionality:

```bash
# 1. Assign a certificate to a namespace
./otdfctl policy certificates assign \
  --namespace "https://example.com" \
  --file ../platform/keys/kas-cert.pem \
  --label "source=kas-cert" \
  --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' \
  --host http://localhost:8080

# Note the Certificate ID from the output for later use

# 2. View namespace with certificates
./otdfctl policy certificates show \
  --namespace-id "https://example.com" \
  --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' \
  --host http://localhost:8080

# 3. List certificates
./otdfctl policy certificates list \
  --namespace-id "https://example.com" \
  --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' \
  --host http://localhost:8080

# 4. Remove certificate from namespace
./otdfctl policy certificates remove \
  --namespace "https://example.com" \
  --certificate-id "<certificate-id-from-step-1>" \
  --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' \
  --host http://localhost:8080

# 5. Convert PEM to x5c format (utility command)
./otdfctl policy certificates convert-pem --file ../platform/keys/kas-cert.pem
```

## Certificate Format

**PEM Format** (input):
```
-----BEGIN CERTIFICATE-----
MIICjTCCAhSgAwIBAgIIdebfy8FoW6gwCgYIKoZIzj0EAwIwfDELMAkGA1UEBhMC
...
-----END CERTIFICATE-----
```

**x5c Format** (stored):
```
MIICjTCCAhSgAwIBAgIIdebfy8FoW6gwCgYIKoZIzj0EAwIwfDELMAkGA1UEBhMC...
```

The x5c format is the base64-encoded DER (Distinguished Encoding Rules) representation of the certificate without PEM headers/footers.
