### PR TITLE
fix(core): render kas-registry key list-mappings table rows

### DIFF
--- a/cmd/kas-keys.go
+++ b/cmd/kas-keys.go
@@ -560,8 +560,7 @@ func policyListKeyMappings(cmd *cobra.Command, args []string) {
 		table.NewFlexColumn("namespace_mappings", "Namespaces", cli.FlexColumnWidthThree),
 		table.NewFlexColumn("attribute_mappings", "Attributes", cli.FlexColumnWidthThree),
 		table.NewFlexColumn("value_mappings", "Values", cli.FlexColumnWidthThree),
-	)
-	t.WithRows(rows)
+	).WithRows(rows)
 	t = cli.WithListPaginationFooter(t, resp.GetPagination())
 
 	HandleSuccess(cmd, "", t, resp)


### PR DESCRIPTION
<img width="1089" height="153" alt="Screenshot 2025-10-03 at 2 12 59 PM" src="https://github.com/user-attachments/assets/74486fcf-ad43-4e22-b80a-1fc751e7d9df" />

Table formatting for overflow values needs more attention throughout CLI outputs and is out of scope for this fix. 