### PR TITLE
fix(core): Provider config manager table field empty

### DIFF
--- a/cmd/keymanagement-provider.go
+++ b/cmd/keymanagement-provider.go
@@ -29,7 +29,7 @@ func createProviderConfig(cmd *cobra.Command, args []string) {
 		{"ID", pc.GetId()},
 		{"Name", pc.GetName()},
 		{"Config", string(pc.GetConfigJson())},
-		{"Manager", string(pc.GetManager())},
+		{"Manager", pc.GetManager()},
 	}
 
 	if mdRows := getMetadataRows(pc.GetMetadata()); mdRows != nil {
@@ -58,7 +58,7 @@ func getProviderConfig(cmd *cobra.Command, args []string) {
 		{"ID", pc.GetId()},
 		{"Name", pc.GetName()},
 		{"Config", string(pc.GetConfigJson())},
-		{"Manager", string(pc.GetManager())},
+		{"Manager", pc.GetManager()},
 	}
 
 	if mdRows := getMetadataRows(pc.GetMetadata()); mdRows != nil {
@@ -94,7 +94,7 @@ func updateProviderConfig(cmd *cobra.Command, args []string) {
 		{"ID", pc.GetId()},
 		{"Name", pc.GetName()},
 		{"Config", string(pc.GetConfigJson())},
-		{"Manager", string(pc.GetManager())},
+		{"Manager", pc.GetManager()},
 	}
 
 	if mdRows := getMetadataRows(pc.GetMetadata()); mdRows != nil {
@@ -140,7 +140,7 @@ func listProviderConfig(cmd *cobra.Command, args []string) {
 			"labels":     metadata["Labels"],
 			"created_at": metadata["Created At"],
 			"updated_at": metadata["Updated At"],
-			"manager":    string(pc.GetManager()),
+			"manager":    pc.GetManager(),
 		}))
 	}
 	t = t.WithRows(rows)


### PR DESCRIPTION
1. Populate `manager` field in table output

<img width="1329" height="176" alt="Screenshot 2025-10-09 at 12 17 33 PM" src="https://github.com/user-attachments/assets/176debc1-12d3-4d6f-87e7-f3c0a6f0268c" />
