### PR TITLE
fix(core): Ensure IDs are displayed for keys.

### DIFF
--- a/cmd/kas-keys.go
+++ b/cmd/kas-keys.go
@@ -427,8 +427,8 @@ func policyListKasKeys(cmd *cobra.Command, args []string) {
 	t := cli.NewTable(
 		// columns should be id, name, config, labels, created_at, updated_at
 		cli.NewUUIDColumn(),
-		table.NewFlexColumn("keyId", "Key ID", cli.FlexColumnWidthOne),
 		table.NewFlexColumn("kasUri", "KAS URI", cli.FlexColumnWidthThree),
+		table.NewFlexColumn("keyId", "Key ID", cli.FlexColumnWidthOne),
 		table.NewFlexColumn("keyAlgorithm", "Key Algorithm", cli.FlexColumnWidthOne),
 		table.NewFlexColumn("keyStatus", "Key Status", cli.FlexColumnWidthOne),
 		table.NewFlexColumn("keyMode", "Key Mode", cli.FlexColumnWidthOne),
@@ -452,8 +452,8 @@ func policyListKasKeys(cmd *cobra.Command, args []string) {
 
 		rows = append(rows, table.NewRow(table.RowData{
 			"id":           key.GetId(),
-			"keyId":        key.GetKeyId(),
 			"kasUri":       kasKey.GetKasUri(),
+			"keyId":        key.GetKeyId(),
 			"keyAlgorithm": algStr,
 			"keyStatus":    statusStr,
 			"keyMode":      modeStr,


### PR DESCRIPTION
- Ensure that all kas-key commands display the id of the key properly.
- Remove Public/Private key context from the table display
- Remove Provider configuration from the table display
- Add `KAS URI` to List Keys command

1.) Create, Update, Get, Rotate, Import
<img width="1581" height="222" alt="Screenshot 2025-10-23 at 2 09 11 PM" src="https://github.com/user-attachments/assets/8ffd8337-9c9b-4399-8d5d-fb5cccdfb3d3" />


2.) List Keys
<img width="1578" height="205" alt="Screenshot 2025-10-23 at 2 16 03 PM" src="https://github.com/user-attachments/assets/71eafb98-e7e3-4021-be1a-34f5e76b6e75" />





