### PR TITLE
fix(main): Subject mapping tests

### DIFF
--- a/e2e/subject-mapping.bats
+++ b/e2e/subject-mapping.bats
@@ -95,8 +95,16 @@ teardown_file() {
 }
 
 @test "Get subject mapping" {
-    new_scs=$(./otdfctl $HOST $WITH_CREDS policy scs create -s "$SCS_2" --json | jq -r '.id')
-    created=$(./otdfctl $HOST $WITH_CREDS policy sm create -a "$SM_VAL2_ID" --action "custom_sm_action_test" --subject-condition-set-id "$new_scs" --json | jq -r '.id')
+    run ./otdfctl $HOST $WITH_CREDS policy scs create -s "$SCS_2" --json
+    assert_success
+    new_scs=$(echo "$output" | jq -r '.id')
+    assert [[ -n "$new_scs" && "$new_scs" != "null" ]]
+
+    run ./otdfctl $HOST $WITH_CREDS policy sm create -a "$SM_VAL2_ID" --action "custom_sm_action_test" --subject-condition-set-id "$new_scs" --json
+    assert_success
+    created=$(echo "$output" | jq -r '.id')
+    assert [[ -n "$created" && "$created" != "null" ]]
+    
     # table
     run_otdfctl_sm get --id "$created"
         assert_success
@@ -116,18 +124,15 @@ teardown_file() {
 
 @test "Update a subject mapping" {
     run ./otdfctl $HOST $WITH_CREDS policy sm create -a "$SM_VAL1_ID" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json
+    assert_success
     created=$(echo "$output" | jq -r '.id')
-    assert [ "$created" != "null" ]
-    assert [ -n "$created" ]
+    assert [[ -n "$created" && "$created" != "null" ]]
     
     # Create additional SCS and verify it was created successfully
     run ./otdfctl $HOST $WITH_CREDS policy scs create -s "$SCS_2" --json
     assert_success
     additional_scs=$(echo "$output" | jq -r '.id')
-    assert [ "$additional_scs" != "null" ]
-    assert [ -n "$additional_scs" ]
-    
-
+    assert [[ -n "$additional_scs" && "$additional_scs" != "null" ]]
 
     # replace the action (always destructive replacement)
     run_otdfctl_sm update --id "$created" --action "$ACTION_CREATE_NAME" --json


### PR DESCRIPTION
1.) The `update` subject mapping test is currently flaky, add a debug log and asserts to ensure that the necessary fixtures are created first.

>[!NOTE]
>It's probable this happens again, but at least we will have some debug logs to figure out what is going on. The error was that the subject condition set was not always being created before trying to update to it.