### PR TITLE
fix(core): improve TLS error handling UX when connecting to platform

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -180,7 +180,7 @@ func NewHandler(c *cli.Cli) handlers.Handler {
 	if err := auth.ValidateProfileAuthCredentials(c.Context(), cp); err != nil {
 		var certErr *tls.CertificateVerificationError
 		if errors.As(err, &certErr) {
-			cli.ExitWithError(fmt.Sprintf("Failed to trust TLS certificates served at '%s'. Caution: if host is correct and insecure certificates should be dangerously trusted, use '--tls-no-verify'", cp.GetEndpoint()), nil)
+			cli.ExitWithError(fmt.Sprintf("Failed to validate TLS certificates served at '%s'. Caution: if host is correct and insecure certificates should be dangerously trusted, use '--tls-no-verify'", cp.GetEndpoint()), nil)
 		}
 		if errors.Is(err, sdk.ErrPlatformUnreachable) {
 			cli.ExitWithError(fmt.Sprintf("Failed to connect to the platform. Is the platform accepting connections at '%s'?", cp.GetEndpoint()), nil)


### PR DESCRIPTION
Inform the user there is an untrusted cert issue and prompt them about dangerously ignoring certificate validation with `--tls-no-verify`.

<figure>
  <img width="972" height="296" alt="Screenshot 2025-12-01 at 2 49 02 PM" src="https://github.com/user-attachments/assets/d62eacac-51d9-4e2a-b6af-3e49b53169a5" />
  <figcaption>Properly skipped verification with `tls-no-verify`, improved verification error UX, and differentiated error UX when paltform is unreachable altogether.</figcaption>
</figure>

