### PR TITLE
fix(core)!: remove NanoTDF support

### DIFF
--- a/cmd/tdf/encrypt.go
+++ b/cmd/tdf/encrypt.go
@@ -43,7 +43,6 @@ func encryptRun(cmd *cobra.Command, args []string) {
 	tdfType := c.Flags.GetOptionalString("tdf-type")
 	kasURLPath := c.Flags.GetOptionalString("kas-url-path")
 	wrappingKeyAlgStr := c.Flags.GetOptionalString("wrapping-key-algorithm")
-	policyMode := c.Flags.GetOptionalString("policy-mode")
 	targetMode := c.Flags.GetOptionalString("target-mode")
 	var wrappingKeyAlgorithm ocrypto.KeyType
 	switch wrappingKeyAlgStr {
@@ -115,10 +114,8 @@ func encryptRun(cmd *cobra.Command, args []string) {
 		attrValues,
 		fileMimeType,
 		kasURLPath,
-		c.Flags.GetOptionalBool("ecdsa-binding"),
 		assertions,
 		wrappingKeyAlgorithm,
-		policyMode,
 		targetMode,
 	)
 	if err != nil {
@@ -185,20 +182,10 @@ func InitEncryptCommand() {
 		encryptDoc.GetDocFlag("wrapping-key-algorithm").Default,
 		encryptDoc.GetDocFlag("wrapping-key-algorithm").Description,
 	)
-	encryptDoc.Flags().Bool(
-		encryptDoc.GetDocFlag("ecdsa-binding").Name,
-		false,
-		encryptDoc.GetDocFlag("ecdsa-binding").Description,
-	)
 	encryptDoc.Flags().String(
 		encryptDoc.GetDocFlag("kas-url-path").Name,
 		encryptDoc.GetDocFlag("kas-url-path").Default,
 		encryptDoc.GetDocFlag("kas-url-path").Description,
-	)
-	encryptDoc.Flags().String(
-		encryptDoc.GetDocFlag("policy-mode").Name,
-		encryptDoc.GetDocFlag("policy-mode").Default,
-		encryptDoc.GetDocFlag("policy-mode").Description,
 	)
 	encryptDoc.Flags().String(
 		encryptDoc.GetDocFlag("target-mode").Name,

--- a/docs/man/encrypt/_index.md
+++ b/docs/man/encrypt/_index.md
@@ -23,20 +23,14 @@ command:
       description: The MIME type of the input data. If not provided, the MIME type is inferred from the input data.
     - name: tdf-type
       shorthand: t
-      description: The type of tdf to encrypt as. ZTDF supports structured manifests and larger payloads. NanoTDF has a smaller footprint and more performant, but does not support structured manifests or large payloads. (tdf3 is an alias for ztdf)
+      description: The type of TDF to encrypt as (tdf3 is an alias for ztdf).
       enum:
         - ztdf
         - tdf3
-        - nano
       default: ztdf
-    - name: ecdsa-binding
-      description: For nano type containers only, enables ECDSA policy binding
     - name: kas-url-path
       description: URL path to the KAS service at the platform endpoint domain. Leading slash is required if needed.
       default: /kas
-    - name: policy-mode
-      description: How the policy is stored within the object (currently nanoTDF only) [plaintext|encrypted]. Defaults to encrypted.
-      default: ""
     - name: target-mode
       description: The target TDF spec version (e.g., "4.3.0"); intended for legacy compatibility and subject to removal.
       default: ""
@@ -102,16 +96,6 @@ restrict access to the data based on entity entitlements.
 ```shell
 # output to hello.txt.tdf with attribute
 otdfctl encrypt hello.txt --out hello.txt.tdf --attr https://example.com/attr/attr1/value/value1
-```
-
-## NanoTDF
-
-NanoTDF is a lightweight TDF format that is more performant and has a smaller footprint than ZTDF. NanoTDF does not
-support structured manifests or large payloads.
-
-```shell
-# output to nano.tdf
-otdfctl encrypt hello.txt --tdf-type nano --out hello.txt.tdf
 ```
 
 ## ZTDF Assertions (experimental)

--- a/e2e/testrail-integration/samples-for-virtru-instance/testname-to-testrail-id.virtru.json
+++ b/e2e/testrail-integration/samples-for-virtru-instance/testname-to-testrail-id.virtru.json
@@ -41,21 +41,13 @@
     "roundtrip TDF3, assertions, stdin": "C797127",
     "roundtrip TDF3, assertions with HS256 keys and verification, file": "C797128",
     "roundtrip TDF3, assertions with RS256 keys and verification, file": "C797129",
-    "roundtrip NANO, no attributes, file": "C793426",
-    "roundtrip NANO, no attributes, file, ecdsa binding": "C793427",
-    "roundtrip NANO, one attribute, stdin": "C793428",
-    "roundtrip NANO, one attribute, stdin, plaintext policy mode": "C874680",
-    "roundtrip NANO, one attribute, mixed case FQN, stdin": "C793429",
     "roundtrip TDF3, with target version < 4.3.0": "C871544",
     "roundtrip TDF3, with target version >= 4.3.0": "C871545",
     "roundtrip TDF3, with allowlist containing platform kas": "C871546",
     "roundtrip TDF3, with allowlist containing non existent kas (should fail)": "C871547",
     "roundtrip TDF3, ignoring allowlist": "C871548",
-    "roundtrip NANO, with allowlist containing platform kas": "C871549",
-    "roundtrip NANO, with allowlist containing non existent kas (should fail)": "C871550",
-    "roundtrip NANO, ignoring allowlist": "C871551",
-    "roundtrip TDF3/Nano, not entitled to data, no required obligations returned": "C875374",
-    "roundtrip TDF3/Nano, entitled to data, required obligations returned": "C875375"
+    "roundtrip TDF3, not entitled to data, no required obligations returned": "C875374",
+    "roundtrip TDF3, entitled to data, required obligations returned": "C875375"
   },
   "KAS Grants": {
     "Unassign rejects more than one type of grant at once": "C793434",

--- a/pkg/cli/printer.go
+++ b/pkg/cli/printer.go
@@ -1,4 +1,3 @@
-//nolint:forbidigo // print statements require flexibility
 package cli
 
 import (

--- a/pkg/tdf/tdf.go
+++ b/pkg/tdf/tdf.go
@@ -1,7 +1,6 @@
 package tdf
 
 const (
-	TypeZTDF    = "ztdf"
-	TypeTDF3    = "tdf3" // alias for TDF
-	TypeNanoTDF = "nano"
+	TypeZTDF = "ztdf"
+	TypeTDF3 = "tdf3" // alias for TDF
 )


### PR DESCRIPTION
Remove NanoTDF ("nano" tdf-type) support from encrypt/decrypt/inspect, docs, and e2e coverage. This drops nano-only flags like --ecdsa-binding and --policy-mode. Tests: go test ./... -short -race -cover; golangci-lint run; go build ./....