### PR TITLE
chore(ci): Update go toolchain to latest 1.24.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/otdfctl
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.12
 
 require (
 	github.com/adrg/frontmatter v0.2.0


### PR DESCRIPTION
This may quiet down govulncheck