### PR TITLE
fix(core): unsafe update result output values order

### DIFF
--- a/cmd/policy/attributes.go
+++ b/cmd/policy/attributes.go
@@ -239,33 +239,34 @@ func unsafeUpdateAttribute(cmd *cobra.Command, args []string) {
 		cli.ConfirmTextInput(cli.ActionUpdateUnsafe, "attribute", cli.InputNameFQN, a.GetFqn())
 	}
 
-	if err := h.UnsafeUpdateAttribute(ctx, id, name, rule, attributeValuesOrder, allowTraversal); err != nil {
+	updatedAttr, err := h.UnsafeUpdateAttribute(ctx, id, name, rule, attributeValuesOrder, allowTraversal)
+	if err != nil {
 		cli.ExitWithError(fmt.Sprintf("Failed to update attribute (%s)", id), err)
 	} else {
 		var (
 			retrievedVals []string
 			valueIDs      []string
 		)
-		for _, v := range a.GetValues() {
+		for _, v := range updatedAttr.GetValues() {
 			retrievedVals = append(retrievedVals, v.GetValue())
 			valueIDs = append(valueIDs, v.GetId())
 		}
 		if allowTraversal == nil {
-			allowTraversal = a.GetAllowTraversal()
+			allowTraversal = updatedAttr.GetAllowTraversal()
 		}
 		rows := [][]string{
-			{"Id", a.GetId()},
-			{"Name", a.GetName()},
-			{"Rule", handlers.GetAttributeRuleFromAttributeType(a.GetRule())},
+			{"Id", updatedAttr.GetId()},
+			{"Name", updatedAttr.GetName()},
+			{"Rule", handlers.GetAttributeRuleFromAttributeType(updatedAttr.GetRule())},
 			{"Values", cli.CommaSeparated(retrievedVals)},
 			{"Value IDs", cli.CommaSeparated(valueIDs)},
 			{"Allow Traversal", allowTraversal.String()},
 		}
-		if mdRows := getMetadataRows(a.GetMetadata()); mdRows != nil {
+		if mdRows := getMetadataRows(updatedAttr.GetMetadata()); mdRows != nil {
 			rows = append(rows, mdRows...)
 		}
 		t := cli.NewTabular(rows...)
-		common.HandleSuccess(cmd, id, t, a)
+		common.HandleSuccess(cmd, id, t, updatedAttr)
 	}
 }
 

--- a/e2e/attributes.bats
+++ b/e2e/attributes.bats
@@ -232,6 +232,11 @@ teardown_file() {
   [ "$(echo "$output" | jq -r '.values[0].value')" = "val2" ]
   [ "$(echo "$output" | jq -r '.values[1].value')" = "val1" ]
 
+  # ensure non-JSON output reflects reordered values immediately
+  run_otdfctl_attr unsafe update --id "$CREATED_ID" --values-order "$VAL1_ID" --values-order "$VAL2_ID" --force
+  assert_success
+  assert_line --regexp "Value IDs\\s+│\\[$VAL1_ID, $VAL2_ID\\]"
+
   run_otdfctl_attr unsafe update --id "$CREATED_ID" --allow-traversal --json --force
   assert_success
   run_otdfctl_attr get --id "$CREATED_ID" --json

--- a/pkg/handlers/attribute.go
+++ b/pkg/handlers/attribute.go
@@ -140,7 +140,7 @@ func (h Handler) UnsafeDeleteAttribute(ctx context.Context, id, fqn string) erro
 }
 
 // Deletes and returns error if deletion failed
-func (h Handler) UnsafeUpdateAttribute(ctx context.Context, id, name, rule string, valuesOrder []string, allowTraversal *wrapperspb.BoolValue) error {
+func (h Handler) UnsafeUpdateAttribute(ctx context.Context, id, name, rule string, valuesOrder []string, allowTraversal *wrapperspb.BoolValue) (*policy.Attribute, error) {
 	req := &unsafe.UnsafeUpdateAttributeRequest{
 		Id:   id,
 		Name: name,
@@ -149,7 +149,7 @@ func (h Handler) UnsafeUpdateAttribute(ctx context.Context, id, name, rule strin
 	if rule != "" {
 		r, err := GetAttributeRuleFromReadableString(rule)
 		if err != nil {
-			return fmt.Errorf("invalid attribute rule: %s", rule)
+			return nil, fmt.Errorf("invalid attribute rule: %s", rule)
 		}
 		req.Rule = r
 	}
@@ -161,7 +161,10 @@ func (h Handler) UnsafeUpdateAttribute(ctx context.Context, id, name, rule strin
 	}
 
 	_, err := h.sdk.Unsafe.UnsafeUpdateAttribute(ctx, req)
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return h.GetAttribute(ctx, id)
 }
 
 func (h Handler) AssignKeyToAttribute(ctx context.Context, attr, keyID string) (*attributes.AttributeKey, error) {


### PR DESCRIPTION
Ensure unsafely updating the order of attribute values on a definition is properly reflected in the table output