### PR TITLE
chore(ci): DSPX-2960 - bump Go toolchain to 1.25.9 to fix govulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/otdfctl
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/adrg/frontmatter v0.2.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from `go1.25.8` to `go1.25.9` in `go.mod` to resolve 4 standard library vulnerabilities flagged by `govulncheck`:

| CVE | Package | Description |
|-----|---------|-------------|
| GO-2026-4947 | `crypto/x509` | Unexpected work during chain building |
| GO-2026-4946 | `crypto/x509` | Inefficient policy validation |
| GO-2026-4870 | `crypto/tls` | Unauthenticated TLS 1.3 KeyUpdate causes DoS |
| GO-2026-4865 | `html/template` | XSS via JsBraceDepth context tracking |

No code changes required — this is a patch release with no breaking changes. `go mod tidy && go build ./...` verified clean after the bump.

## Test plan

- [x] `govulncheck` step passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)