### PR TITLE
docs: add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # otdfctl: cli to manage OpenTDF Platform
 
+> [!WARNING]
+> This repository has been archived and is no longer actively maintained.
+
 This command line interface is used to manage OpenTDF Platform.
 
 The main goals are to:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > [!WARNING]
 > This repository has been archived and is no longer actively maintained.
+>
+> The codebase and CLI have been moved to the [OpenTDF Platform monorepo](https://github.com/opentdf/platform/tree/main/otdfctl).
 
 This command line interface is used to manage OpenTDF Platform.
 


### PR DESCRIPTION
## Summary
- Adds a visible warning banner to the top of the README indicating that the repository has been archived and is no longer actively maintained.

## Test plan
- [ ] Verify the warning renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an archived repository warning to the README to inform users that the repository is no longer actively maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->